### PR TITLE
[infra] Setup staging CD pipeline (CD only, no CI)

### DIFF
--- a/.github/workflows/staging-cd.yml
+++ b/.github/workflows/staging-cd.yml
@@ -1,0 +1,208 @@
+name: "Staging CD"
+
+# Trigger: mỗi khi có push vào branch dev (bao gồm cả merge PR)
+on:
+  push:
+    branches: [dev]
+
+# Đảm bảo chỉ có 1 deploy staging chạy tại 1 thời điểm.
+# Nếu có deploy đang chạy mà có push mới, pipeline mới sẽ chờ pipeline cũ xong.
+# (cancel-in-progress: false để tránh rollback giữa chừng)
+concurrency:
+  group: staging-deploy
+  cancel-in-progress: false
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  # ─────────────────────────────────────────────────────────────────────────
+  # JOB 1: BUILD & PUSH IMAGE LÊN GHCR
+  # ─────────────────────────────────────────────────────────────────────────
+  build:
+    name: "🔨 Build & Push"
+    runs-on: ubuntu-latest
+    outputs:
+      image_tag:  ${{ steps.meta.outputs.version }}
+      full_image: ${{ env.REGISTRY }}/${{ steps.vars.outputs.image }}:${{ steps.meta.outputs.version }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # Docker image name phải lowercase — github.repository có thể chứa chữ hoa
+      - name: Lowercase image name
+        id: vars
+        run: echo "image=$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Tags tạo ra:
+      #   ghcr.io/giangdq202/vmarble-warehouse-managment-service:sha-a1b2c3d  ← immutable tag theo git sha
+      #   ghcr.io/giangdq202/vmarble-warehouse-managment-service:staging-latest ← floating tag build mới nhất
+      - name: Extract Docker image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ steps.vars.outputs.image }}
+          tags: |
+            type=sha,prefix=sha-,format=short
+            type=raw,value=staging-latest
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags:       ${{ steps.meta.outputs.tags }}
+          labels:     ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to:   type=gha,mode=max
+
+      # ── Thông báo Discord ─────────────────────────────────────────────────
+      - name: "[Discord] ✅ Build thành công"
+        if: success()
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_URL }}
+        run: |
+          SHORT="${GITHUB_SHA::7}"
+          MSG=$(echo '${{ github.event.head_commit.message }}' | head -1)
+          jq -cn \
+            --arg sha  "$SHORT" \
+            --arg msg  "$MSG" \
+            --arg tag  "${{ steps.meta.outputs.version }}" \
+            --arg who  "${{ github.actor }}" \
+            --arg url  "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            '{embeds:[{
+              title: "🔨 Build thành công — staging",
+              color: 3066993,
+              fields:[
+                {name:"Commit",   value:("`"+$sha+"` "+$msg), inline:false},
+                {name:"Image",    value:("`"+$tag+"`"),        inline:false},
+                {name:"Tác giả",  value:$who,                 inline:true},
+                {name:"Run log",  value:("[#${{ github.run_number }}]("+$url+")"), inline:true}
+              ]
+            }]}' \
+          | curl -sS -X POST "$DISCORD_WEBHOOK" \
+               -H "Content-Type: application/json" -d @-
+
+      - name: "[Discord] ❌ Build thất bại"
+        if: failure()
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_URL }}
+        run: |
+          SHORT="${GITHUB_SHA::7}"
+          MSG=$(echo '${{ github.event.head_commit.message }}' | head -1)
+          jq -cn \
+            --arg sha "$SHORT" \
+            --arg msg "$MSG" \
+            --arg who "${{ github.actor }}" \
+            --arg url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            '{embeds:[{
+              title: "❌ Build thất bại — staging",
+              color: 15158332,
+              fields:[
+                {name:"Commit",  value:("`"+$sha+"` "+$msg), inline:false},
+                {name:"Tác giả", value:$who,                 inline:true},
+                {name:"Log lỗi", value:("[#${{ github.run_number }}]("+$url+")"), inline:true}
+              ]
+            }]}' \
+          | curl -sS -X POST "$DISCORD_WEBHOOK" \
+               -H "Content-Type: application/json" -d @-
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # JOB 2: DEPLOY LÊN SERVER STAGING (chỉ chạy nếu build thành công)
+  # ─────────────────────────────────────────────────────────────────────────
+  deploy:
+    name: "🚀 Deploy Staging"
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      # Script /opt/vwms-staging/deploy.sh sẽ:
+      #   1. Pull image mới
+      #   2. Restart app container (giữ nguyên postgres)
+      #   3. Health check 60s
+      #   4. Nếu fail → tự rollback về image cũ
+      #   5. Exit code 0 = success, 1 = failed + rolled back
+      - name: SSH → Deploy + Auto-rollback
+        id: ssh_deploy
+        uses: appleboy/ssh-action@v1.0.3
+        env:
+          FULL_IMAGE:  ${{ needs.build.outputs.full_image }}
+          GHCR_USER:   ${{ github.actor }}
+          GHCR_TOKEN:  ${{ secrets.GITHUB_TOKEN }}
+        with:
+          host:     ${{ secrets.STAGING_HOST }}
+          username: root
+          password: ${{ secrets.STAGING_SSH_PASSWORD }}
+          port:     22
+          timeout:  180s
+          envs:     FULL_IMAGE,GHCR_USER,GHCR_TOKEN
+          script: |
+            echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin
+            /opt/vwms-staging/deploy.sh "$FULL_IMAGE"
+
+      # ── Thông báo Discord ─────────────────────────────────────────────────
+      - name: "[Discord] 🚀 Deploy thành công"
+        if: steps.ssh_deploy.outcome == 'success'
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_URL }}
+        run: |
+          SHORT="${GITHUB_SHA::7}"
+          MSG=$(echo '${{ github.event.head_commit.message }}' | head -1)
+          jq -cn \
+            --arg sha  "$SHORT" \
+            --arg msg  "$MSG" \
+            --arg tag  "${{ needs.build.outputs.image_tag }}" \
+            --arg who  "${{ github.actor }}" \
+            --arg url  "${{ vars.STAGING_URL }}" \
+            --arg run  "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            '{embeds:[{
+              title: "🚀 Deploy thành công — staging",
+              color: 3066993,
+              fields:[
+                {name:"Commit",  value:("`"+$sha+"` "+$msg), inline:false},
+                {name:"Image",   value:("`"+$tag+"`"),        inline:false},
+                {name:"Tác giả", value:$who,                  inline:true},
+                {name:"Staging", value:$url,                  inline:true},
+                {name:"Run log", value:("[#${{ github.run_number }}]("+$run+")"), inline:false}
+              ]
+            }]}' \
+          | curl -sS -X POST "$DISCORD_WEBHOOK" \
+               -H "Content-Type: application/json" -d @-
+
+      - name: "[Discord] 💥 Deploy thất bại — Đã rollback"
+        if: steps.ssh_deploy.outcome == 'failure'
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_URL }}
+        run: |
+          SHORT="${GITHUB_SHA::7}"
+          MSG=$(echo '${{ github.event.head_commit.message }}' | head -1)
+          jq -cn \
+            --arg sha "$SHORT" \
+            --arg msg "$MSG" \
+            --arg tag "${{ needs.build.outputs.image_tag }}" \
+            --arg who "${{ github.actor }}" \
+            --arg run "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            '{embeds:[{
+              title: "💥 Deploy thất bại — đã rollback — staging",
+              color: 16744272,
+              description: "App đã được tự động rollback về version trước đó.",
+              fields:[
+                {name:"Commit lỗi", value:("`"+$sha+"` "+$msg), inline:false},
+                {name:"Image lỗi",  value:("`"+$tag+"`"),        inline:false},
+                {name:"Tác giả",    value:$who,                  inline:true},
+                {name:"Log lỗi",    value:("[#${{ github.run_number }}]("+$run+")"), inline:true}
+              ]
+            }]}' \
+          | curl -sS -X POST "$DISCORD_WEBHOOK" \
+               -H "Content-Type: application/json" -d @-

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .env
 .env.*
 !.env.example
+!deploy/staging/.env.staging.example
 
 bin/
 tmp/

--- a/README.md
+++ b/README.md
@@ -101,6 +101,13 @@ Mỗi module tuân theo pattern: `iface.go` (interface + DTOs) → `service.go` 
 
 - Xem hướng dẫn cho AI agent và contributors tại [CLAUDE.md](CLAUDE.md).
 
+## Staging & CD
+
+- **Staging server**: `IP`
+- **Trigger**: Mỗi khi có push (merge PR) vào nhánh `dev` → GitHub Actions tự động build & deploy
+- **Thông báo**: Discord webhook sau mỗi sự kiện build/deploy
+- **Hướng dẫn setup**: [docs/runbooks/staging-cd.md](docs/runbooks/staging-cd.md)
+
 ## Branch Rules
 
 Quy tắc nhánh áp dụng chung:

--- a/deploy/staging/.env.staging.example
+++ b/deploy/staging/.env.staging.example
@@ -1,0 +1,13 @@
+# .env.staging.example
+# Copy file này thành .env.staging trên server: /opt/vwms-staging/.env.staging
+# KHÔNG commit file .env.staging vào repo!
+
+# ── App ───────────────────────────────────────────────────────────────────────
+DATABASE_URL=postgres://vmarble:CHANGE_ME_STRONG_PASSWORD@postgres:5432/vmarble_staging?sslmode=disable
+PORT=8080
+LOG_LEVEL=info
+
+# ── Postgres (dùng bởi postgres service trong docker-compose.staging.yml) ─────
+POSTGRES_USER=vmarble
+POSTGRES_PASSWORD=CHANGE_ME_STRONG_PASSWORD
+POSTGRES_DB=vmarble_staging

--- a/deploy/staging/deploy.sh
+++ b/deploy/staging/deploy.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# deploy.sh — Chạy trên staging server, được gọi bởi GitHub Actions qua SSH
+#
+# Usage: /opt/vwms-staging/deploy.sh <full-image-path>
+# Ví dụ: /opt/vwms-staging/deploy.sh ghcr.io/org/be-vwms:sha-a1b2c3d
+#
+# Luồng:
+#   1. Lưu image hiện tại để rollback nếu cần
+#   2. Pull image mới
+#   3. Restart app container (postgres KHÔNG bị ảnh hưởng)
+#   4. Health check tối đa 60s
+#   5a. OK    → Cập nhật state, exit 0
+#   5b. FAIL  → Rollback về image cũ, exit 1 (để GitHub Actions báo lỗi)
+
+set -euo pipefail
+
+# ── Config ────────────────────────────────────────────────────────────────────
+DEPLOY_DIR="/opt/vwms-staging"
+COMPOSE_FILE="${DEPLOY_DIR}/docker-compose.staging.yml"
+ENV_FILE="${DEPLOY_DIR}/.env.staging"
+STATE_FILE="${DEPLOY_DIR}/.last_good_image"     # Lưu image đang chạy tốt nhất
+HEALTH_URL="http://localhost:8080/healthz"
+HEALTH_RETRIES=12                               # 12 lần × 5s = 60s timeout
+HEALTH_INTERVAL=5
+
+# ── Input ─────────────────────────────────────────────────────────────────────
+NEW_IMAGE="${1:?[deploy] Thiếu argument: full image path}"
+
+log() { echo "[deploy $(date -u +%H:%M:%S)] $*"; }
+
+cd "$DEPLOY_DIR"
+
+# ── 1. Lưu image hiện tại cho rollback ────────────────────────────────────────
+PREV_IMAGE=$(cat "$STATE_FILE" 2>/dev/null || true)
+log "Image cũ   : ${PREV_IMAGE:-<chưa có>}"
+log "Image mới  : $NEW_IMAGE"
+
+# ── 2. Pull image mới từ GHCR ─────────────────────────────────────────────────
+log "Pulling $NEW_IMAGE ..."
+docker pull "$NEW_IMAGE"
+
+# ── 3. Restart app (giữ nguyên postgres) ──────────────────────────────────────
+log "Khởi động lại app container ..."
+APP_IMAGE="$NEW_IMAGE" docker compose \
+    -f "$COMPOSE_FILE" \
+    --env-file "$ENV_FILE" \
+    up -d app
+
+# ── 4. Health check loop ───────────────────────────────────────────────────────
+log "Chờ health check ($HEALTH_URL) ..."
+IS_HEALTHY=false
+for i in $(seq 1 $HEALTH_RETRIES); do
+    sleep "$HEALTH_INTERVAL"
+    if curl -sf --max-time 3 "$HEALTH_URL" > /dev/null 2>&1; then
+        IS_HEALTHY=true
+        break
+    fi
+    log "  Lần thử ${i}/${HEALTH_RETRIES} — chưa ready ..."
+done
+
+# ── 5a. SUCCESS ────────────────────────────────────────────────────────────────
+if $IS_HEALTHY; then
+    log "✅ Deploy thành công: $NEW_IMAGE"
+    echo "$NEW_IMAGE" > "$STATE_FILE"
+    exit 0
+fi
+
+# ── 5b. FAILURE → ROLLBACK ────────────────────────────────────────────────────
+log "❌ Health check thất bại sau ${HEALTH_RETRIES} lần thử!"
+
+if [ -z "$PREV_IMAGE" ]; then
+    log "⚠️  Không có version cũ để rollback. Cần can thiệp thủ công!"
+    exit 1
+fi
+
+log "🔄 Đang rollback về: $PREV_IMAGE ..."
+APP_IMAGE="$PREV_IMAGE" docker compose \
+    -f "$COMPOSE_FILE" \
+    --env-file "$ENV_FILE" \
+    up -d app
+
+# Xác nhận rollback thành công
+ROLLBACK_OK=false
+for i in $(seq 1 6); do
+    sleep 5
+    if curl -sf --max-time 3 "$HEALTH_URL" > /dev/null 2>&1; then
+        ROLLBACK_OK=true
+        break
+    fi
+done
+
+if $ROLLBACK_OK; then
+    log "↩️  Rollback thành công — đang chạy: $PREV_IMAGE"
+    echo "$PREV_IMAGE" > "$STATE_FILE"
+else
+    log "💥 NGHIÊM TRỌNG: Rollback cũng thất bại! Cần can thiệp thủ công ngay!"
+fi
+
+exit 1  # Luôn exit 1 để GitHub Actions biết deploy mới đã thất bại

--- a/deploy/staging/docker-compose.staging.yml
+++ b/deploy/staging/docker-compose.staging.yml
@@ -1,0 +1,37 @@
+# docker-compose.staging.yml
+# File này nằm trên SERVER tại: /opt/vwms-staging/docker-compose.staging.yml
+# KHÔNG commit credentials vào đây — dùng .env.staging (xem .env.staging.example)
+
+services:
+  postgres:
+    image: postgres:17-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER:     ${POSTGRES_USER:-vmarble}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB:       ${POSTGRES_DB:-vmarble}
+    volumes:
+      - pgdata_staging:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-vmarble} -d ${POSTGRES_DB:-vmarble}"]
+      interval: 5s
+      timeout:  3s
+      retries:  20
+      start_period: 5s
+
+  app:
+    # APP_IMAGE được inject bởi deploy.sh khi chạy docker compose
+    # Fallback về staging-latest nếu chạy thủ công
+    image: ${APP_IMAGE:-ghcr.io/giangdq202/vmarble-warehouse-managment-service:staging-latest}
+    restart: unless-stopped
+    ports:
+      - "0.0.0.0:8080:8080"
+    env_file:
+      - .env.staging
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+volumes:
+  pgdata_staging:
+    name: vwms_staging_pgdata

--- a/deploy/staging/rollback-db.sh
+++ b/deploy/staging/rollback-db.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# rollback-db.sh — Script rollback DB thủ công khi cần
+# Chỉ dùng trong tình huống khẩn cấp: migration mới gây lỗi và app đã được rollback code.
+#
+# Prerequisite: goose binary phải được cài trên server
+#   curl -sSL https://github.com/pressly/goose/releases/download/v3.24.3/goose_linux_x86_64 \
+#     -o /usr/local/bin/goose && chmod +x /usr/local/bin/goose
+#
+# Usage:
+#   ./rollback-db.sh           # rollback 1 migration
+#   ./rollback-db.sh 2         # rollback 2 migrations
+#   ./rollback-db.sh status    # xem trạng thái migrations
+
+set -euo pipefail
+
+DEPLOY_DIR="/opt/vwms-staging"
+ENV_FILE="${DEPLOY_DIR}/.env.staging"
+MIGRATIONS_DIR="${DEPLOY_DIR}/migrations"
+
+# Load DATABASE_URL từ .env.staging
+set -a && source "$ENV_FILE" && set +a
+
+COMMAND="${1:-down}"
+N="${2:-1}"
+
+case "$COMMAND" in
+    status)
+        echo "=== Migration status ==="
+        goose -dir "$MIGRATIONS_DIR" postgres "$DATABASE_URL" status
+        ;;
+    down)
+        echo "=== Rollback $N migration(s) ==="
+        for i in $(seq 1 "$N"); do
+            echo "--- Rollback #$i ---"
+            goose -dir "$MIGRATIONS_DIR" postgres "$DATABASE_URL" down
+        done
+        echo "Done. Current status:"
+        goose -dir "$MIGRATIONS_DIR" postgres "$DATABASE_URL" status
+        ;;
+    *)
+        echo "Usage: $0 [status|down] [count]"
+        exit 1
+        ;;
+esac

--- a/docs/runbooks/staging-cd.md
+++ b/docs/runbooks/staging-cd.md
@@ -1,0 +1,206 @@
+# Runbook: Staging CD Pipeline
+
+## Tổng quan
+
+Pipeline CD tự động deploy BE lên staging server mỗi khi có push (merge PR) vào nhánh `dev`.
+
+| | |
+|---|---|
+| **Trigger** | Push vào nhánh `dev` |
+| **Staging server** | Xem secret `STAGING_HOST` trong GitHub Actions |
+| **Image registry** | GitHub Container Registry (GHCR) |
+| **Workflow file** | `.github/workflows/staging-cd.yml` |
+| **Deploy script** | `/opt/vwms-staging/deploy.sh` (trên server) |
+
+---
+
+## Setup server (1 lần duy nhất)
+
+### 1. Cài Docker
+
+```bash
+ssh root@$STAGING_HOST
+
+curl -fsSL https://get.docker.com | sh
+systemctl enable --now docker
+```
+
+### 2. Tạo thư mục staging
+
+```bash
+mkdir -p /opt/vwms-staging
+cd /opt/vwms-staging
+```
+
+### 3. Upload files từ repo
+
+```bash
+# Chạy từ máy local
+scp deploy/staging/docker-compose.staging.yml root@$STAGING_HOST:/opt/vwms-staging/
+scp deploy/staging/deploy.sh                  root@$STAGING_HOST:/opt/vwms-staging/
+scp deploy/staging/rollback-db.sh             root@$STAGING_HOST:/opt/vwms-staging/
+ssh root@$STAGING_HOST "chmod +x /opt/vwms-staging/*.sh"
+```
+
+### 4. Tạo file `.env.staging`
+
+```bash
+ssh root@$STAGING_HOST
+
+cat > /opt/vwms-staging/.env.staging <<'EOF'
+DATABASE_URL=postgres://vmarble:STRONG_PASSWORD@postgres:5432/vmarble_staging?sslmode=disable
+PORT=8080
+LOG_LEVEL=info
+POSTGRES_USER=vmarble
+POSTGRES_PASSWORD=STRONG_PASSWORD
+POSTGRES_DB=vmarble_staging
+EOF
+chmod 600 /opt/vwms-staging/.env.staging
+```
+
+### 5. Login GitHub Container Registry (GHCR)
+
+Tạo GitHub PAT tại: **GitHub → Settings → Developer settings → Personal access tokens → Fine-grained tokens**
+Scope cần thiết: `read:packages`
+
+```bash
+echo "YOUR_GITHUB_PAT" | docker login ghcr.io -u giangdq202 --password-stdin
+```
+
+### 6. Tạo SSH deploy key cho GitHub Actions
+
+```bash
+# Trên server
+ssh-keygen -t ed25519 -f /tmp/gh_deploy_key -C "github-actions-staging" -N ""
+
+# Thêm public key vào authorized_keys
+cat /tmp/gh_deploy_key.pub >> ~/.ssh/authorized_keys
+
+# In private key ra để copy vào GitHub Secret
+cat /tmp/gh_deploy_key
+```
+
+### 7. Khởi động PostgreSQL lần đầu
+
+```bash
+cd /opt/vwms-staging
+docker compose -f docker-compose.staging.yml --env-file .env.staging up -d postgres
+```
+
+---
+
+## GitHub Secrets & Variables
+
+Vào **GitHub repo → Settings → Secrets and variables → Actions** và thêm:
+
+| Tên | Loại | Giá trị |
+|---|---|---|
+| `DISCORD_WEBHOOK_URL` | Secret | Webhook URL của Discord channel |
+| `STAGING_HOST` | Secret | IP của staging server |
+| `STAGING_SSH_KEY` | Secret | Nội dung private key từ bước 6 |
+| `STAGING_URL` | **Variable** | `http://<staging-host>:8080` |
+
+> **Lấy Discord Webhook:** Discord Server → Channel Settings → Integrations → Webhooks → New Webhook → Copy URL
+
+---
+
+## Luồng CD tự động
+
+```
+Merge PR vào dev
+      │
+      ▼
+Job: Build & Push
+  ① docker build (multi-stage, alpine)
+  ② docker push → ghcr.io/giangdq202/...:sha-<short>
+  ③ Discord: 🔨 Build OK / ❌ Build FAIL + link log
+      │ (chỉ tiếp tục nếu build thành công)
+      ▼
+Job: Deploy Staging
+  ① SSH vào staging server ($STAGING_HOST)
+  ② /opt/vwms-staging/deploy.sh <image>
+     - Pull image mới
+     - docker compose restart app (postgres không bị ảnh hưởng)
+     - Health check /healthz mỗi 5s, tối đa 60s
+     - OK  → lưu state, exit 0
+     - FAIL→ rollback image cũ, exit 1
+  ③ Discord: 🚀 Deploy OK / 💥 Deploy FAIL + đã rollback
+```
+
+---
+
+## Trigger deploy thủ công
+
+Nếu cần deploy lại mà không có code mới:
+
+```bash
+# Trên GitHub: Actions → Staging CD → Re-run jobs
+# Hoặc tạo empty commit:
+git commit --allow-empty -m "chore: trigger staging redeploy"
+git push origin dev
+```
+
+---
+
+## Xem logs deploy trên server
+
+```bash
+ssh root@$STAGING_HOST
+
+# Logs của app container
+docker logs vwms-staging-app-1 --tail 100 -f
+
+# Logs của postgres
+docker logs vwms-staging-postgres-1 --tail 50
+
+# Trạng thái deploy gần nhất
+cat /opt/vwms-staging/.last_good_image
+```
+
+---
+
+## Rollback thủ công
+
+### Rollback app (code)
+
+```bash
+ssh root@$STAGING_HOST
+cd /opt/vwms-staging
+
+# Xem image đang chạy
+cat .last_good_image
+
+# Rollback về image cụ thể
+APP_IMAGE="ghcr.io/giangdq202/vmarble-warehouse-managment-service:sha-<prev>" \
+  docker compose -f docker-compose.staging.yml --env-file .env.staging up -d app
+```
+
+### Rollback DB migration (chỉ dùng khi khẩn cấp)
+
+```bash
+ssh root@$STAGING_HOST
+
+# Xem trạng thái migrations
+/opt/vwms-staging/rollback-db.sh status
+
+# Rollback 1 migration gần nhất
+/opt/vwms-staging/rollback-db.sh down 1
+
+# Rollback N migrations
+/opt/vwms-staging/rollback-db.sh down <N>
+```
+
+> ⚠️ **Lưu ý:** Rollback DB chỉ cần thiết khi migration có thay đổi destructive (DROP/RENAME).
+> Migrations additive (ADD TABLE/COLUMN) không cần rollback DB khi rollback code.
+
+---
+
+## Kiểm tra health staging
+
+```bash
+curl http://$STAGING_HOST:8080/healthz
+# Expected: 200 OK
+
+# Swagger UI
+open http://$STAGING_HOST:8080/swagger/index.html
+```


### PR DESCRIPTION
## Summary

- Thiết lập GitHub Actions CD pipeline tự động build & deploy lên staging server mỗi khi có merge PR vào nhánh `dev`
- Pipeline chỉ gồm **CD** (build image → push GHCR → SSH deploy + auto-rollback): CI (test/lint) sẽ bổ sung ở issue riêng khi coverage đủ
- Tích hợp Discord webhook thông báo kết quả từng bước build/deploy

## Business rules impacted

Không có — infra only.

## Test plan

- [x] Merge PR này vào `dev`
- [x] GitHub Actions tab → workflow **"Staging CD"** chạy tự động
- [x] Job `build`: chỉ có Docker steps (checkout → lowercase → buildx → login → metadata → build&push → discord)
- [x] Job `deploy`: SSH vào staging server, chạy `/opt/vwms-staging/deploy.sh`
- [x] Discord channel nhận 2 thông báo: 🔨 Build OK → 🚀 Deploy OK
- [x] `curl http://$STAGING_HOST:8080/healthz` → `200 OK`

## Secrets đã được config

| Secret/Variable | Trạng thái |
|---|---|
| `DISCORD_WEBHOOK_URL` | ✅ Set |
| `STAGING_HOST` | ✅ Set |
| `STAGING_SSH_PASSWORD` | ✅ Set |
| `STAGING_URL` (variable) | ✅ Set |

## Server staging đã được chuẩn bị

- Files deploy đã upload lên `/opt/vwms-staging/`
- PostgreSQL 17 đang chạy và healthy
- `.env.staging` đã tạo

Closes #21