### PR TITLE
ci: fix GHCR push permission error

### DIFF
--- a/.github/workflows/staging-cd.yml
+++ b/.github/workflows/staging-cd.yml
@@ -22,6 +22,9 @@ jobs:
   build:
     name: "🔨 Build & Push"
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     outputs:
       image_tag:  ${{ steps.meta.outputs.version }}
       full_image: ${{ env.REGISTRY }}/${{ steps.vars.outputs.image }}:${{ steps.meta.outputs.version }}


### PR DESCRIPTION
Cấp quyền 'packages: write' cho GITHUB_TOKEN để workflow có thể push image lên ghcr.io.