### PR TITLE
chore: expose postgres port on staging

### DIFF
--- a/deploy/staging/docker-compose.staging.yml
+++ b/deploy/staging/docker-compose.staging.yml
@@ -6,6 +6,8 @@ services:
   postgres:
     image: postgres:17-alpine
     restart: unless-stopped
+    ports:
+      - "127.0.0.1:5432:5432"
     environment:
       POSTGRES_USER:     ${POSTGRES_USER:-vmarble}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}


### PR DESCRIPTION
## Mô tả thay đổi\n- Cấu hình Postgres port  map vào  trên server staging.\n- Mục đích: Cho phép truy cập DB an toàn thông qua SSH Tunnel mà không cần mở cổng ra internet.