### PR TITLE
Docs/add gemini guidelines

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -43,10 +43,18 @@ Each module (e.g., `catalog`) must adhere to a 5-file structure:
   - DB table/column names: `snake_case`.
   - JSON tags: `snake_case`.
 
-## 5. Database Strategy on Staging/Prod (Fix-forward)
-- **Never use `migrate-down`** on Staging or Production environments.
-- All database errors or schema changes must be handled by creating a **new migration file** (Fix-forward) to ensure traceability.
-- Staging DB access is only allowed via **SSH Tunnel** (Port `5432` mapped to `127.0.0.1` on the server).
+## 5. Database & API Strategy on Staging/Prod (Security)
+- **Zero Public Ports**: No ports (except SSH 22) are exposed to the public Internet on Staging.
+- **Mandatory SSH Tunnel**: Access to both **PostgreSQL (5432)** and **Backend API (8080)** is only allowed via SSH Tunnel.
+- **SSH Config Example**:
+  ```ssh
+  Host staging
+      HostName 163.61.182.158
+      User root
+      LocalForward 5432 127.0.0.1:5432
+      LocalForward 8080 127.0.0.1:8080
+  ```
+- **Fix-forward Migration**: Never use `migrate-down` on Staging or Production. All changes must be handled by creating a new migration file.
 
 ## 6. Collaboration Conventions
 ### Branch Naming

--- a/deploy/staging/docker-compose.staging.yml
+++ b/deploy/staging/docker-compose.staging.yml
@@ -1,6 +1,6 @@
 # docker-compose.staging.yml
-# File này nằm trên SERVER tại: /opt/vwms-staging/docker-compose.staging.yml
-# KHÔNG commit credentials vào đây — dùng .env.staging (xem .env.staging.example)
+# This file resides on the STAGING SERVER at: /opt/vwms-staging/docker-compose.staging.yml
+# DO NOT commit credentials here — use .env.staging
 
 services:
   postgres:
@@ -22,8 +22,7 @@ services:
       start_period: 5s
 
   app:
-    # APP_IMAGE được inject bởi deploy.sh khi chạy docker compose
-    # Fallback về staging-latest nếu chạy thủ công
+    # APP_IMAGE is injected by deploy.sh during deployment
     image: ${APP_IMAGE:-ghcr.io/giangdq202/vmarble-warehouse-managment-service:staging-latest}
     restart: unless-stopped
     ports:

--- a/deploy/staging/docker-compose.staging.yml
+++ b/deploy/staging/docker-compose.staging.yml
@@ -27,7 +27,7 @@ services:
     image: ${APP_IMAGE:-ghcr.io/giangdq202/vmarble-warehouse-managment-service:staging-latest}
     restart: unless-stopped
     ports:
-      - "0.0.0.0:8080:8080"
+      - "127.0.0.1:8080:8080"
     env_file:
       - .env.staging
     depends_on:


### PR DESCRIPTION
This pull request strengthens the security of the staging environment by enforcing stricter access controls and clarifies deployment documentation. The most significant changes include updating documentation to reflect new security practices, restricting API access to localhost, and improving comments for clarity.

**Security enhancements:**

* Updated the security policy in `GEMINI.md` to require zero public ports (except SSH 22) on staging, and mandated SSH tunneling for both PostgreSQL (5432) and backend API (8080) access. Provided an example SSH config for connecting securely.
* Modified `docker-compose.staging.yml` so the app service only binds the API port (8080) to `127.0.0.1`, ensuring the backend is not publicly accessible.

**Documentation improvements:**

* Clarified comments in `docker-compose.staging.yml` to use English and to instruct not to commit credentials, referencing the use of `.env.staging` for secrets.
* Updated comments for the app image in `docker-compose.staging.yml` to explain that the image is injected by the deployment script.