### PR TITLE
[staging] expose app port to all interfaces for WireGuard VPN access

### DIFF
--- a/deploy/staging/docker-compose.staging.yml
+++ b/deploy/staging/docker-compose.staging.yml
@@ -26,7 +26,7 @@ services:
     image: ${APP_IMAGE:-ghcr.io/giangdq202/vmarble-warehouse-management-service:staging-latest}
     restart: unless-stopped
     ports:
-      - "127.0.0.1:8080:8080"
+      - "0.0.0.0:8080:8080"
     env_file:
       - .env.staging
     depends_on:


### PR DESCRIPTION
## Summary

- Đổi bind port của app container từ `127.0.0.1:8080` → `0.0.0.0:8080` để VPN client (WireGuard subnet `10.8.0.0/24`) có thể truy cập staging API tại `10.8.0.1:8080`
- Truy cập từ internet vẫn bị chặn ở tầng UFW (`deny in on eth0 port 8080`)

## Context

Staging server đã được setup WireGuard VPN native (thay thế wg-easy Docker). Dev team và khách hàng UAT truy cập app qua VPN — không expose public URL. Thay đổi này sync file trong repo với config đang chạy thực tế trên server.

## Test plan

- [x] Kết nối WireGuard VPN → `curl http://10.8.0.1:8080/healthz` → 200 OK
- [x] Ngắt VPN → `curl http://163.61.182.158:8080/healthz` → timeout/refused

🤖 Generated with [Claude Code](https://claude.com/claude-code)