### PR TITLE
feat(ci): add discord notifications for CI steps and fix failure alert

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -43,6 +43,30 @@ jobs:
           version: latest
 
       # ── Thông báo Discord ───────────────────────────────────────────────
+      - name: "[Discord] ✅ Lint/Test thành công"
+        if: success()
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_URL }}
+        run: |
+          SHORT="${GITHUB_SHA::7}"
+          MSG=$(echo '${{ github.event.head_commit.message }}' | head -1)
+          jq -cn \
+            --arg sha "$SHORT" \
+            --arg msg "$MSG" \
+            --arg who "${{ github.actor }}" \
+            --arg url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            '{embeds:[{
+              title: "✅ Lint/Test thành công",
+              color: 3066993,
+              fields:[
+                {name:"Commit",  value:("`"+$sha+"` "+$msg), inline:false},
+                {name:"Tác giả", value:$who,                 inline:true},
+                {name:"Run log", value:("[#${{ github.run_number }}]("+$url+")"), inline:true}
+              ]
+            }]}' \
+          | curl -sS -X POST "$DISCORD_WEBHOOK" \
+               -H "Content-Type: application/json" -d @-
+
       - name: "[Discord] ❌ Lint/Test thất bại"
         if: failure()
         env:

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -209,7 +209,7 @@ jobs:
 
       # ── Thông báo Discord ─────────────────────────────────────────────────
       - name: "[Discord] 🚀 Deploy thành công"
-        if: steps.ssh_deploy.outcome == 'success'
+        if: success() && steps.ssh_deploy.outcome == 'success'
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_URL }}
         run: |
@@ -235,7 +235,7 @@ jobs:
                -H "Content-Type: application/json" -d @-
 
       - name: "[Discord] 💥 Deploy thất bại — Đã rollback"
-        if: steps.ssh_deploy.outcome == 'failure'
+        if: failure() && steps.ssh_deploy.outcome == 'failure'
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_URL }}
         run: |


### PR DESCRIPTION
### Summary
- Added **Success (✅)** Discord notification for Quality (Lint & Test) job.
- Fixed **Failure (💥)** Discord notification for Deploy job by adding `failure()` condition (previously skipped on error).
- Unified notification style across all jobs (Quality, Build, Deploy).

### Why?
The previous PR #66 fixed the CI failure but didn't address missing notifications when a job failed (especially in the Deploy step). These updates ensure full visibility into the pipeline's health.

### Test Plan
- [x] Commits pushed to branch `fix/workflow-lint-version`.
- [x] Verified logic in `.github/workflows/staging.yml`.