### PR TITLE
refactor: optimize Makefile to load env and cleanup redundant logic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,14 @@
 .PHONY: dev run build test test-integration lint swagger migrate-up migrate-down migrate-create docker-up docker-down
 
+# Load .env if it exists
+ifneq (,$(wildcard ./.env))
+    include .env
+    export
+endif
+
 APP_NAME := warehouse-server
-PG_PORT  ?= 5433
-DSN      ?= postgres://vmarble:vmarble@localhost:$(PG_PORT)/vmarble?sslmode=disable
+PG_PORT  ?= 5432
+DSN      := $(DATABASE_URL)
 GOOSE    ?= go run github.com/pressly/goose/v3/cmd/goose@v3.24.3
 SWAG     ?= go run github.com/swaggo/swag/cmd/swag@v1.8.12
 
@@ -11,8 +17,7 @@ SWAG     ?= go run github.com/swaggo/swag/cmd/swag@v1.8.12
 dev: docker-up migrate-up run
 
 run:
-	@set -a; [ -f .env ] && . ./.env; set +a; \
-	DATABASE_URL="$${DATABASE_URL:-"$(DSN)"}" go run ./cmd/server
+	go run ./cmd/server
 
 build:
 	go build -o bin/$(APP_NAME) ./cmd/server


### PR DESCRIPTION
This pull request updates the `Makefile` to improve environment variable handling and simplify the development workflow. The most significant changes involve loading environment variables from a `.env` file if present, standardizing the Postgres port, and simplifying the `run` target.

**Environment variable management:**

* The `Makefile` now automatically loads and exports variables from a `.env` file if it exists, making local configuration more seamless.
* The `DSN` variable is now set from `DATABASE_URL` (typically defined in `.env`), aligning with common practices for environment-based configuration.

**Development workflow simplification:**

* The `run` target has been simplified to just run `go run ./cmd/server`, removing the inline shell logic for loading `.env` and setting `DATABASE_URL`. This relies on the new automatic `.env` loading at the top of the `Makefile`.
* The default Postgres port (`PG_PORT`) is changed from `5433` to the more standard `5432`.