### PR TITLE
[chore] ignore .planning/ directory from version control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ server
 # Test coverage artifacts
 *.out
 *.prof
+
+# Local planning artifacts (GSD - not shared with team)
+.planning/


### PR DESCRIPTION
## Summary
- Add `.planning/` to `.gitignore` so local GSD planning artifacts are not tracked or shared with other developers

## Business rule(s) impacted
N/A — tooling/config change only

## Test plan
- [x] Verify `.planning/` does not appear in `git status` after the change