### PR TITLE
[infra] migrate staging logging to journald

### DIFF
--- a/deploy/staging/docker-compose.staging.yml
+++ b/deploy/staging/docker-compose.staging.yml
@@ -10,10 +10,9 @@ services:
       - "127.0.0.1:5432:5432"
       - "10.8.0.1:5432:5432"
     logging:
-      driver: "json-file"
+      driver: "journald"
       options:
-        max-size: "100m"
-        max-file: "3"
+        tag: "vwms-staging-postgres"
     environment:
       POSTGRES_USER:     ${POSTGRES_USER:-vmarble}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
@@ -34,10 +33,9 @@ services:
       - "127.0.0.1:8080:8080"
       - "10.8.0.1:8080:8080"
     logging:
-      driver: "json-file"
+      driver: "journald"
       options:
-        max-size: "100m"
-        max-file: "3"
+        tag: "vwms-staging-app" # Cần sửa thủ công postgres thành tag riêng sau khi replace
     env_file:
       - .env.staging
     depends_on:


### PR DESCRIPTION
## Summary
Switch Docker logging driver from json-file to journald for persistent logs across deployments.

## Business rules impacted
None (Infrastructure change).

## Test plan
[x] Verified on staging server with journalctl.
[x] Verified docker-compose config syntax.