### PR TITLE
[infra] auto cleanup docker resources after successful deploy

### DIFF
--- a/deploy/staging/deploy.sh
+++ b/deploy/staging/deploy.sh
@@ -62,6 +62,11 @@ done
 if $IS_HEALTHY; then
     log "✅ Deploy thành công: $NEW_IMAGE"
     echo "$NEW_IMAGE" > "$STATE_FILE"
+    
+    # Tự động dọn dẹp Docker sau khi deploy thành công (dọn images cũ, v.v.)
+    log "🧹 Đang dọn dẹp Docker rác ..."
+    docker system prune -af > /dev/null 2>&1 || true
+    
     exit 0
 fi
 


### PR DESCRIPTION
## Summary
Add 'docker system prune -af' to deploy script to prevent disk space accumulation on staging.

## Business rules impacted
None (Infrastructure cleanup).

## Test plan
[x] Verified script syntax.
[x] Manually ran cleanup on staging server.