### PR TITLE
[infra] Cấu hình SSH secret port 2288 cho workflow

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -226,7 +226,7 @@ jobs:
           host:     ${{ secrets.STAGING_HOST }}
           username: root
           password: ${{ secrets.STAGING_SSH_PASSWORD }}
-          port:     22
+          port:     ${{ secrets.STAGING_SSH_PORT }}
           timeout:  180s
           envs:     FULL_IMAGE,GHCR_USER,GHCR_TOKEN
           script: |


### PR DESCRIPTION
### Summary
Cập nhật workflow staging để sử dụng secret  thay vì cổng 22 mặc định. Đã cấu hình secret 2288 trên GitHub.

### Business Rules Impacted
Infra security.

### Test Plan
Kiểm tra pipeline Staging khi có push vào .

Closes #171