### PR TITLE
fix: use STAGING_USER secret instead of hardcoded username

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -223,7 +223,7 @@ jobs:
           GHCR_TOKEN:  ${{ secrets.GITHUB_TOKEN }}
         with:
           host:     ${{ secrets.STAGING_HOST }}
-          username: deploy_vwms
+          username: ${{ secrets.STAGING_USER }}
           key: ${{ secrets.STAGING_SSH_KEY }}
           port:     ${{ secrets.STAGING_SSH_PORT }}
           timeout:  180s


### PR DESCRIPTION
Quick fix to use STAGING_USER secret variable instead of hardcoded 'deploy_vwms' username.

This allows flexible SSH user configuration (now using 'root' user).

Related to #260