### PR TITLE
[chore] install ECC skills + block-no-verify hook

### DIFF
--- a/.claude/hooks/block-no-verify.js
+++ b/.claude/hooks/block-no-verify.js
@@ -1,0 +1,546 @@
+#!/usr/bin/env node
+/**
+ * PreToolUse Hook: Block --no-verify flag
+ *
+ * Blocks git hook-bypass flags (--no-verify, -c core.hooksPath=) to protect
+ * pre-commit, commit-msg, and pre-push hooks from being skipped by AI agents.
+ *
+ * Replaces the previous npx-based invocation that failed in pnpm-only projects
+ * (EBADDEVENGINES) and could not be disabled via ECC_DISABLED_HOOKS.
+ *
+ * Exit codes:
+ *   0 = allow (not a git command or no bypass flags)
+ *   2 = block (bypass flag detected)
+ */
+
+'use strict';
+
+const MAX_STDIN = 1024 * 1024;
+let raw = '';
+
+/**
+ * Git commands that support the --no-verify flag.
+ */
+const GIT_COMMANDS_WITH_NO_VERIFY = [
+  'commit',
+  'push',
+  'merge',
+  'cherry-pick',
+  'rebase',
+  'am',
+];
+
+/**
+ * Characters that can appear immediately before 'git' in a command string.
+ */
+const VALID_BEFORE_GIT = ' \t\n\r;&|$`(<{!"\']/.~\\';
+
+// Git config section and variable names are case-insensitive
+// (subsection names are case-sensitive but core.hooksPath has none),
+// so we normalize the candidate token to lowercase before matching.
+// See https://git-scm.com/docs/git-config — "The variable names are
+// case-insensitive."
+const GIT_CONFIG_KEY_PREFIX = 'core.hookspath=';
+
+const COMMIT_OPTIONS_WITH_VALUE = new Set([
+  '-m',
+  '--message',
+  '-F',
+  '--file',
+  '-C',
+  '--reuse-message',
+  '-c',
+  '--reedit-message',
+  '--author',
+  '--date',
+  '--template',
+  '--fixup',
+  '--squash',
+  '--pathspec-from-file',
+]);
+
+const COMMIT_OPTIONS_WITH_INLINE_VALUE = [
+  '--message=',
+  '--file=',
+  '--reuse-message=',
+  '--reedit-message=',
+  '--author=',
+  '--date=',
+  '--template=',
+  '--fixup=',
+  '--squash=',
+  '--pathspec-from-file=',
+];
+
+// Short options that take a value. When seen as part of a combined
+// short-option token (e.g. -tn), git's parser treats the rest of the
+// token as the option's value (template path 'n' here), so the scanner
+// must stop at this character — anything after it is the inline value,
+// not another flag.
+const COMMIT_SHORT_OPTIONS_WITH_VALUE = new Set(['m', 'F', 'C', 'c', 't']);
+
+function tokenizeShellWords(input, start = 0, end = input.length) {
+  const tokens = [];
+  let value = '';
+  let tokenStart = null;
+  let quote = null;
+  let escaped = false;
+
+  function beginToken(index) {
+    if (tokenStart === null) {
+      tokenStart = index;
+    }
+  }
+
+  function pushToken(index) {
+    if (tokenStart === null) {
+      return;
+    }
+
+    tokens.push({
+      value,
+      start: tokenStart,
+      end: index,
+    });
+    value = '';
+    tokenStart = null;
+  }
+
+  for (let i = start; i < end; i++) {
+    const char = input.charAt(i);
+
+    if (escaped) {
+      beginToken(i - 1);
+      value += char;
+      escaped = false;
+      continue;
+    }
+
+    if (quote) {
+      if (char === quote) {
+        quote = null;
+        continue;
+      }
+
+      if (quote === '"' && char === '\\') {
+        beginToken(i);
+        escaped = true;
+        continue;
+      }
+
+      beginToken(i);
+      value += char;
+      continue;
+    }
+
+    if (char === '"' || char === "'") {
+      beginToken(i);
+      quote = char;
+      continue;
+    }
+
+    if (char === '\\') {
+      beginToken(i);
+      escaped = true;
+      continue;
+    }
+
+    if (/\s/.test(char)) {
+      pushToken(i);
+      continue;
+    }
+
+    beginToken(i);
+    value += char;
+  }
+
+  if (escaped) {
+    value += '\\';
+  }
+  pushToken(end);
+
+  return tokens;
+}
+
+function findCommandSegmentEnd(input, start) {
+  let quote = null;
+  let escaped = false;
+
+  for (let i = start; i < input.length; i++) {
+    const char = input.charAt(i);
+
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+
+    if (quote) {
+      if (quote === '"' && char === '\\') {
+        escaped = true;
+        continue;
+      }
+      if (char === quote) {
+        quote = null;
+      }
+      continue;
+    }
+
+    if (char === '"' || char === "'") {
+      quote = char;
+      continue;
+    }
+
+    if (char === '\\') {
+      escaped = true;
+      continue;
+    }
+
+    if (char === ';' || char === '|' || char === '&' || char === '\n') {
+      return i;
+    }
+  }
+
+  return input.length;
+}
+
+function commitOptionConsumesNextValue(value) {
+  if (isCommitNoVerifyShortFlag(value)) {
+    return false;
+  }
+
+  if (COMMIT_OPTIONS_WITH_VALUE.has(value)) {
+    return true;
+  }
+
+  const shortValueOption = getCommitShortValueOption(value);
+  return Boolean(shortValueOption && shortValueOption.consumesNextValue);
+}
+
+function commitOptionContainsInlineValue(value) {
+  if (isCommitNoVerifyShortFlag(value)) {
+    return false;
+  }
+
+  if (COMMIT_OPTIONS_WITH_INLINE_VALUE.some(prefix => value.startsWith(prefix))) {
+    return true;
+  }
+
+  const shortValueOption = getCommitShortValueOption(value);
+  return Boolean(shortValueOption && shortValueOption.containsInlineValue);
+}
+
+function getCommitShortValueOption(value) {
+  if (!value.startsWith('-') || value.startsWith('--') || value === '-') {
+    return null;
+  }
+
+  const options = value.slice(1);
+  for (let i = 0; i < options.length; i++) {
+    if (COMMIT_SHORT_OPTIONS_WITH_VALUE.has(options.charAt(i))) {
+      return {
+        consumesNextValue: i === options.length - 1,
+        containsInlineValue: i < options.length - 1,
+      };
+    }
+  }
+
+  return null;
+}
+
+function isCommitNoVerifyShortFlag(value) {
+  return value === '-n' || /^-n[a-zA-Z]/.test(value);
+}
+
+/**
+ * Check if a position in the input is inside a shell comment.
+ */
+function isInComment(input, idx) {
+  const lineStart = input.lastIndexOf('\n', idx - 1) + 1;
+  const before = input.slice(lineStart, idx);
+  for (let i = 0; i < before.length; i++) {
+    if (before.charAt(i) === '#') {
+      const prev = i > 0 ? before.charAt(i - 1) : '';
+      if (prev !== '$' && prev !== '\\') return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Find the next 'git' token in the input starting from a position.
+ */
+function findGit(input, start) {
+  let pos = start;
+  while (pos < input.length) {
+    const idx = input.indexOf('git', pos);
+    if (idx === -1) return null;
+
+    const isExe = input.slice(idx + 3, idx + 7).toLowerCase() === '.exe';
+    const len = isExe ? 7 : 3;
+    const after = input[idx + len] || ' ';
+    if (!/[\s"']/.test(after)) {
+      pos = idx + 1;
+      continue;
+    }
+
+    const before = idx > 0 ? input[idx - 1] : ' ';
+    if (VALID_BEFORE_GIT.includes(before)) return { idx, len };
+    pos = idx + 1;
+  }
+  return null;
+}
+
+/**
+ * Detect which git subcommand (commit, push, etc.) is being invoked.
+ * Returns { command, offset } where offset is the position right after the
+ * subcommand keyword, so callers can scope flag checks to only that portion.
+ */
+function detectGitCommand(input, start = 0) {
+  while (start < input.length) {
+    const git = findGit(input, start);
+    if (!git) return null;
+
+    if (isInComment(input, git.idx)) {
+      start = git.idx + git.len;
+      continue;
+    }
+
+    // Find the first matching subcommand token after "git".
+    // We pick the one closest to "git" so that argument values like
+    // "git push origin commit" don't misclassify "commit" as the subcommand.
+    let bestCmd = null;
+    let bestIdx = Infinity;
+
+    for (const cmd of GIT_COMMANDS_WITH_NO_VERIFY) {
+      let searchPos = git.idx + git.len;
+      while (searchPos < input.length) {
+        const cmdIdx = input.indexOf(cmd, searchPos);
+        if (cmdIdx === -1) break;
+
+        const before = cmdIdx > 0 ? input[cmdIdx - 1] : ' ';
+        const after = input[cmdIdx + cmd.length] || ' ';
+        if (!/\s/.test(before)) { searchPos = cmdIdx + 1; continue; }
+        if (!/[\s;&#|>)\]}"']/.test(after) && after !== '') { searchPos = cmdIdx + 1; continue; }
+        if (/[;|]/.test(input.slice(git.idx + git.len, cmdIdx))) break;
+        if (isInComment(input, cmdIdx)) { searchPos = cmdIdx + 1; continue; }
+
+        // Verify this token is the first non-flag word after "git" — i.e. the
+        // actual subcommand, not an argument value to a different subcommand.
+        const gap = input.slice(git.idx + git.len, cmdIdx);
+        const tokens = gap.trim().split(/\s+/).filter(Boolean);
+        // Every token before the candidate must be a flag or a flag argument.
+        // Git global flags like -c take a value argument (e.g. -c key=value).
+        let onlyFlagsAndArgs = true;
+        let expectFlagArg = false;
+        for (const t of tokens) {
+          if (expectFlagArg) { expectFlagArg = false; continue; }
+          if (t.startsWith('-')) {
+            // -c is a git global flag that takes the next token as its argument
+            if (t === '-c' || t === '-C' || t === '--work-tree' || t === '--git-dir' ||
+                t === '--namespace' || t === '--super-prefix') {
+              expectFlagArg = true;
+            }
+            continue;
+          }
+          onlyFlagsAndArgs = false;
+          break;
+        }
+        if (!onlyFlagsAndArgs) { searchPos = cmdIdx + 1; continue; }
+
+        if (cmdIdx < bestIdx) {
+          bestIdx = cmdIdx;
+          bestCmd = cmd;
+        }
+        break;
+      }
+    }
+
+    if (bestCmd) {
+      return {
+        command: bestCmd,
+        offset: bestIdx + bestCmd.length,
+        gitStart: git.idx,
+        gitEnd: git.idx + git.len,
+        commandStart: bestIdx,
+      };
+    }
+
+    start = git.idx + git.len;
+  }
+  return null;
+}
+
+/**
+ * Check if the input contains a --no-verify flag for a specific git command.
+ * Only inspects the portion of the input starting at `offset` (the position
+ * right after the detected subcommand keyword) so that flags belonging to
+ * earlier commands in a chain are not falsely matched.
+ */
+function hasNoVerifyFlag(input, command, offset) {
+  const segmentEnd = findCommandSegmentEnd(input, offset);
+  const tokens = tokenizeShellWords(input, offset, segmentEnd);
+  let skipNext = false;
+
+  for (const token of tokens) {
+    const value = token.value;
+
+    if (skipNext) {
+      skipNext = false;
+      continue;
+    }
+
+    if (value === '--') {
+      break;
+    }
+
+    if (command === 'commit') {
+      if (commitOptionConsumesNextValue(value)) {
+        skipNext = true;
+        continue;
+      }
+
+      if (commitOptionContainsInlineValue(value)) {
+        continue;
+      }
+    }
+
+    if (value === '--no-verify') return true;
+
+    // For commit, -n is shorthand for --no-verify.
+    if (command === 'commit' && isCommitNoVerifyShortFlag(value)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Check if the input contains a -c core.hooksPath= override.
+ */
+function hasHooksPathOverride(input, detected) {
+  const tokens = tokenizeShellWords(input, detected.gitEnd, detected.commandStart);
+
+  for (let i = 0; i < tokens.length; i++) {
+    const value = tokens[i].value;
+    // Git config section + variable names are case-insensitive, so a
+    // bypass attempt like `core.HOOKSPATH=...` or `core.hookspath=...`
+    // must compare against the lowercased token.
+    const lowered = value.toLowerCase();
+
+    if (value === '-c') {
+      const next = tokens[i + 1] && tokens[i + 1].value;
+      if (typeof next === 'string' && next.toLowerCase().startsWith(GIT_CONFIG_KEY_PREFIX)) {
+        return true;
+      }
+      i++;
+      continue;
+    }
+
+    if (lowered.startsWith(`-c${GIT_CONFIG_KEY_PREFIX}`)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Check a command string for git hook bypass attempts.
+ */
+function checkCommand(input) {
+  let start = 0;
+
+  while (start < input.length) {
+    const detected = detectGitCommand(input, start);
+    if (!detected) return { blocked: false };
+
+    const { command: gitCommand, offset } = detected;
+
+    if (hasHooksPathOverride(input, detected)) {
+      return {
+        blocked: true,
+        reason: `BLOCKED: Overriding core.hooksPath is not allowed with git ${gitCommand}. Git hooks must not be bypassed.`,
+      };
+    }
+
+    if (hasNoVerifyFlag(input, gitCommand, offset)) {
+      return {
+        blocked: true,
+        reason: `BLOCKED: --no-verify flag is not allowed with git ${gitCommand}. Git hooks must not be bypassed.`,
+      };
+    }
+
+    start = findCommandSegmentEnd(input, offset) + 1;
+  }
+
+  return { blocked: false };
+}
+
+/**
+ * Extract the command string from hook input (JSON or plain text).
+ */
+function extractCommand(rawInput) {
+  const trimmed = rawInput.trim();
+  if (!trimmed.startsWith('{')) return trimmed;
+
+  try {
+    const parsed = JSON.parse(trimmed);
+    if (typeof parsed !== 'object' || parsed === null) return trimmed;
+
+    // Claude Code format: { tool_input: { command: "..." } }
+    const cmd = parsed.tool_input?.command;
+    if (typeof cmd === 'string') return cmd;
+
+    // Generic JSON formats
+    for (const key of ['command', 'cmd', 'input', 'shell', 'script']) {
+      if (typeof parsed[key] === 'string') return parsed[key];
+    }
+
+    return trimmed;
+  } catch {
+    return trimmed;
+  }
+}
+
+/**
+ * Exportable run() for in-process execution via run-with-flags.js.
+ */
+function run(rawInput) {
+  const command = extractCommand(rawInput);
+  const result = checkCommand(command);
+
+  if (result.blocked) {
+    return {
+      exitCode: 2,
+      stderr: result.reason,
+    };
+  }
+
+  return { exitCode: 0 };
+}
+
+module.exports = { run };
+
+// Stdin fallback for spawnSync execution — only when invoked directly, not via require()
+if (require.main === module) {
+  process.stdin.setEncoding('utf8');
+  process.stdin.on('data', chunk => {
+    if (raw.length < MAX_STDIN) {
+      const remaining = MAX_STDIN - raw.length;
+      raw += chunk.substring(0, remaining);
+    }
+  });
+
+  process.stdin.on('end', () => {
+    const command = extractCommand(raw);
+    const result = checkCommand(command);
+
+    if (result.blocked) {
+      process.stderr.write(result.reason + '\n');
+      process.exit(2);
+    }
+
+    process.stdout.write(raw);
+  });
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -44,6 +44,10 @@
           {
             "type": "command",
             "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/check-commit-message.sh"
+          },
+          {
+            "type": "command",
+            "command": "node $CLAUDE_PROJECT_DIR/.claude/hooks/block-no-verify.js"
           }
         ]
       }

--- a/.claude/skills/code-tour/SKILL.md
+++ b/.claude/skills/code-tour/SKILL.md
@@ -1,0 +1,236 @@
+---
+name: code-tour
+description: Create CodeTour `.tour` files — persona-targeted, step-by-step walkthroughs with real file and line anchors. Use for onboarding tours, architecture walkthroughs, PR tours, RCA tours, and structured "explain how this works" requests.
+origin: ECC
+---
+
+# Code Tour
+
+Create **CodeTour** `.tour` files for codebase walkthroughs that open directly to real files and line ranges. Tours live in `.tours/` and are meant for the CodeTour format, not ad hoc Markdown notes.
+
+A good tour is a narrative for a specific reader:
+- what they are looking at
+- why it matters
+- what path they should follow next
+
+Only create `.tour` JSON files. Do not modify source code as part of this skill.
+
+## When to Use
+
+Use this skill when:
+- the user asks for a code tour, onboarding tour, architecture walkthrough, or PR tour
+- the user says "explain how X works" and wants a reusable guided artifact
+- the user wants a ramp-up path for a new engineer or reviewer
+- the task is better served by a guided sequence than a flat summary
+
+Examples:
+- onboarding a new maintainer
+- architecture tour for one service or package
+- PR-review walk-through anchored to changed files
+- RCA tour showing the failure path
+- security review tour of trust boundaries and key checks
+
+## When NOT to Use
+
+| Instead of code-tour | Use |
+| --- | --- |
+| A one-off explanation in chat is enough | answer directly |
+| The user wants prose docs, not a `.tour` artifact | `documentation-lookup` or repo docs editing |
+| The task is implementation or refactoring | do the implementation work |
+| The task is broad codebase onboarding without a tour artifact | `codebase-onboarding` |
+
+## Workflow
+
+### 1. Discover
+
+Explore the repo before writing anything:
+- README and package/app entry points
+- folder structure
+- relevant config files
+- the changed files if the tour is PR-focused
+
+Do not start writing steps before you understand the shape of the code.
+
+### 2. Infer the reader
+
+Decide the persona and depth from the request.
+
+| Request shape | Persona | Suggested depth |
+| --- | --- | --- |
+| "onboarding", "new joiner" | `new-joiner` | 9-13 steps |
+| "quick tour", "vibe check" | `vibecoder` | 5-8 steps |
+| "architecture" | `architect` | 14-18 steps |
+| "tour this PR" | `pr-reviewer` | 7-11 steps |
+| "why did this break" | `rca-investigator` | 7-11 steps |
+| "security review" | `security-reviewer` | 7-11 steps |
+| "explain how this feature works" | `feature-explainer` | 7-11 steps |
+| "debug this path" | `bug-fixer` | 7-11 steps |
+
+### 3. Read and verify anchors
+
+Every file path and line anchor must be real:
+- confirm the file exists
+- confirm the line numbers are in range
+- if using a selection, verify the exact block
+- if the file is volatile, prefer a pattern-based anchor
+
+Never guess line numbers.
+
+### 4. Write the `.tour`
+
+Write to:
+
+```text
+.tours/<persona>-<focus>.tour
+```
+
+Keep the path deterministic and readable.
+
+### 5. Validate
+
+Before finishing:
+- every referenced path exists
+- every line or selection is valid
+- the first step is anchored to a real file or directory
+- the tour tells a coherent story rather than listing files
+
+## Step Types
+
+### Content
+
+Use sparingly, usually only for a closing step:
+
+```json
+{ "title": "Next Steps", "description": "You can now trace the request path end to end." }
+```
+
+Do not make the first step content-only.
+
+### Directory
+
+Use to orient the reader to a module:
+
+```json
+{ "directory": "src/services", "title": "Service Layer", "description": "The core orchestration logic lives here." }
+```
+
+### File + line
+
+This is the default step type:
+
+```json
+{ "file": "src/auth/middleware.ts", "line": 42, "title": "Auth Gate", "description": "Every protected request passes here first." }
+```
+
+### Selection
+
+Use when one code block matters more than the whole file:
+
+```json
+{
+  "file": "src/core/pipeline.ts",
+  "selection": {
+    "start": { "line": 15, "character": 0 },
+    "end": { "line": 34, "character": 0 }
+  },
+  "title": "Request Pipeline",
+  "description": "This block wires validation, auth, and downstream execution."
+}
+```
+
+### Pattern
+
+Use when exact lines may drift:
+
+```json
+{ "file": "src/app.ts", "pattern": "export default class App", "title": "Application Entry" }
+```
+
+### URI
+
+Use for PRs, issues, or docs when helpful:
+
+```json
+{ "uri": "https://github.com/org/repo/pull/456", "title": "The PR" }
+```
+
+## Writing Rule: SMIG
+
+Each description should answer:
+- **Situation**: what the reader is looking at
+- **Mechanism**: how it works
+- **Implication**: why it matters for this persona
+- **Gotcha**: what a smart reader might miss
+
+Keep descriptions compact, specific, and grounded in the actual code.
+
+## Narrative Shape
+
+Use this arc unless the task clearly needs something different:
+1. orientation
+2. module map
+3. core execution path
+4. edge case or gotcha
+5. closing / next move
+
+The tour should feel like a path, not an inventory.
+
+## Example
+
+```json
+{
+  "$schema": "https://aka.ms/codetour-schema",
+  "title": "API Service Tour",
+  "description": "Walkthrough of the request path for the payments service.",
+  "ref": "main",
+  "steps": [
+    {
+      "directory": "src",
+      "title": "Source Root",
+      "description": "All runtime code for the service starts here."
+    },
+    {
+      "file": "src/server.ts",
+      "line": 12,
+      "title": "Entry Point",
+      "description": "The server boots here and wires middleware before any route is reached."
+    },
+    {
+      "file": "src/routes/payments.ts",
+      "line": 8,
+      "title": "Payment Routes",
+      "description": "Every payments request enters through this router before hitting service logic."
+    },
+    {
+      "title": "Next Steps",
+      "description": "You can now follow any payment request end to end with the main anchors in place."
+    }
+  ]
+}
+```
+
+## Anti-Patterns
+
+| Anti-pattern | Fix |
+| --- | --- |
+| Flat file listing | Tell a story with dependency between steps |
+| Generic descriptions | Name the concrete code path or pattern |
+| Guessed anchors | Verify every file and line first |
+| Too many steps for a quick tour | Cut aggressively |
+| First step is content-only | Anchor the first step to a real file or directory |
+| Persona mismatch | Write for the actual reader, not a generic engineer |
+
+## Best Practices
+
+- keep step count proportional to repo size and persona depth
+- use directory steps for orientation, file steps for substance
+- for PR tours, cover changed files first
+- for monorepos, scope to the relevant packages instead of touring everything
+- close with what the reader can now do, not a recap
+
+## Related Skills
+
+- `codebase-onboarding`
+- `coding-standards`
+- `council`
+- official upstream format: `microsoft/codetour`

--- a/.claude/skills/database-migrations/SKILL.md
+++ b/.claude/skills/database-migrations/SKILL.md
@@ -1,0 +1,429 @@
+---
+name: database-migrations
+description: Database migration best practices for schema changes, data migrations, rollbacks, and zero-downtime deployments across PostgreSQL, MySQL, and common ORMs (Prisma, Drizzle, Kysely, Django, TypeORM, golang-migrate).
+origin: ECC
+---
+
+# Database Migration Patterns
+
+Safe, reversible database schema changes for production systems.
+
+## When to Activate
+
+- Creating or altering database tables
+- Adding/removing columns or indexes
+- Running data migrations (backfill, transform)
+- Planning zero-downtime schema changes
+- Setting up migration tooling for a new project
+
+## Core Principles
+
+1. **Every change is a migration** — never alter production databases manually
+2. **Migrations are forward-only in production** — rollbacks use new forward migrations
+3. **Schema and data migrations are separate** — never mix DDL and DML in one migration
+4. **Test migrations against production-sized data** — a migration that works on 100 rows may lock on 10M
+5. **Migrations are immutable once deployed** — never edit a migration that has run in production
+
+## Migration Safety Checklist
+
+Before applying any migration:
+
+- [ ] Migration has both UP and DOWN (or is explicitly marked irreversible)
+- [ ] No full table locks on large tables (use concurrent operations)
+- [ ] New columns have defaults or are nullable (never add NOT NULL without default)
+- [ ] Indexes created concurrently (not inline with CREATE TABLE for existing tables)
+- [ ] Data backfill is a separate migration from schema change
+- [ ] Tested against a copy of production data
+- [ ] Rollback plan documented
+
+## PostgreSQL Patterns
+
+### Adding a Column Safely
+
+```sql
+-- GOOD: Nullable column, no lock
+ALTER TABLE users ADD COLUMN avatar_url TEXT;
+
+-- GOOD: Column with default (Postgres 11+ is instant, no rewrite)
+ALTER TABLE users ADD COLUMN is_active BOOLEAN NOT NULL DEFAULT true;
+
+-- BAD: NOT NULL without default on existing table (requires full rewrite)
+ALTER TABLE users ADD COLUMN role TEXT NOT NULL;
+-- This locks the table and rewrites every row
+```
+
+### Adding an Index Without Downtime
+
+```sql
+-- BAD: Blocks writes on large tables
+CREATE INDEX idx_users_email ON users (email);
+
+-- GOOD: Non-blocking, allows concurrent writes
+CREATE INDEX CONCURRENTLY idx_users_email ON users (email);
+
+-- Note: CONCURRENTLY cannot run inside a transaction block
+-- Most migration tools need special handling for this
+```
+
+### Renaming a Column (Zero-Downtime)
+
+Never rename directly in production. Use the expand-contract pattern:
+
+```sql
+-- Step 1: Add new column (migration 001)
+ALTER TABLE users ADD COLUMN display_name TEXT;
+
+-- Step 2: Backfill data (migration 002, data migration)
+UPDATE users SET display_name = username WHERE display_name IS NULL;
+
+-- Step 3: Update application code to read/write both columns
+-- Deploy application changes
+
+-- Step 4: Stop writing to old column, drop it (migration 003)
+ALTER TABLE users DROP COLUMN username;
+```
+
+### Removing a Column Safely
+
+```sql
+-- Step 1: Remove all application references to the column
+-- Step 2: Deploy application without the column reference
+-- Step 3: Drop column in next migration
+ALTER TABLE orders DROP COLUMN legacy_status;
+
+-- For Django: use SeparateDatabaseAndState to remove from model
+-- without generating DROP COLUMN (then drop in next migration)
+```
+
+### Large Data Migrations
+
+```sql
+-- BAD: Updates all rows in one transaction (locks table)
+UPDATE users SET normalized_email = LOWER(email);
+
+-- GOOD: Batch update with progress
+DO $$
+DECLARE
+  batch_size INT := 10000;
+  rows_updated INT;
+BEGIN
+  LOOP
+    UPDATE users
+    SET normalized_email = LOWER(email)
+    WHERE id IN (
+      SELECT id FROM users
+      WHERE normalized_email IS NULL
+      LIMIT batch_size
+      FOR UPDATE SKIP LOCKED
+    );
+    GET DIAGNOSTICS rows_updated = ROW_COUNT;
+    RAISE NOTICE 'Updated % rows', rows_updated;
+    EXIT WHEN rows_updated = 0;
+    COMMIT;
+  END LOOP;
+END $$;
+```
+
+## Prisma (TypeScript/Node.js)
+
+### Workflow
+
+```bash
+# Create migration from schema changes
+npx prisma migrate dev --name add_user_avatar
+
+# Apply pending migrations in production
+npx prisma migrate deploy
+
+# Reset database (dev only)
+npx prisma migrate reset
+
+# Generate client after schema changes
+npx prisma generate
+```
+
+### Schema Example
+
+```prisma
+model User {
+  id        String   @id @default(cuid())
+  email     String   @unique
+  name      String?
+  avatarUrl String?  @map("avatar_url")
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+  orders    Order[]
+
+  @@map("users")
+  @@index([email])
+}
+```
+
+### Custom SQL Migration
+
+For operations Prisma cannot express (concurrent indexes, data backfills):
+
+```bash
+# Create empty migration, then edit the SQL manually
+npx prisma migrate dev --create-only --name add_email_index
+```
+
+```sql
+-- migrations/20240115_add_email_index/migration.sql
+-- Prisma cannot generate CONCURRENTLY, so we write it manually
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_users_email ON users (email);
+```
+
+## Drizzle (TypeScript/Node.js)
+
+### Workflow
+
+```bash
+# Generate migration from schema changes
+npx drizzle-kit generate
+
+# Apply migrations
+npx drizzle-kit migrate
+
+# Push schema directly (dev only, no migration file)
+npx drizzle-kit push
+```
+
+### Schema Example
+
+```typescript
+import { pgTable, text, timestamp, uuid, boolean } from "drizzle-orm/pg-core";
+
+export const users = pgTable("users", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  email: text("email").notNull().unique(),
+  name: text("name"),
+  isActive: boolean("is_active").notNull().default(true),
+  createdAt: timestamp("created_at").notNull().defaultNow(),
+  updatedAt: timestamp("updated_at").notNull().defaultNow(),
+});
+```
+
+## Kysely (TypeScript/Node.js)
+
+### Workflow (kysely-ctl)
+
+```bash
+# Initialize config file (kysely.config.ts)
+kysely init
+
+# Create a new migration file
+kysely migrate make add_user_avatar
+
+# Apply all pending migrations
+kysely migrate latest
+
+# Rollback last migration
+kysely migrate down
+
+# Show migration status
+kysely migrate list
+```
+
+### Migration File
+
+```typescript
+// migrations/2024_01_15_001_create_user_profile.ts
+import { type Kysely, sql } from 'kysely'
+
+// IMPORTANT: Always use Kysely<any>, not your typed DB interface.
+// Migrations are frozen in time and must not depend on current schema types.
+export async function up(db: Kysely<any>): Promise<void> {
+  await db.schema
+    .createTable('user_profile')
+    .addColumn('id', 'serial', (col) => col.primaryKey())
+    .addColumn('email', 'varchar(255)', (col) => col.notNull().unique())
+    .addColumn('avatar_url', 'text')
+    .addColumn('created_at', 'timestamp', (col) =>
+      col.defaultTo(sql`now()`).notNull()
+    )
+    .execute()
+
+  await db.schema
+    .createIndex('idx_user_profile_avatar')
+    .on('user_profile')
+    .column('avatar_url')
+    .execute()
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await db.schema.dropTable('user_profile').execute()
+}
+```
+
+### Programmatic Migrator
+
+```typescript
+import { Migrator, FileMigrationProvider } from 'kysely'
+import { promises as fs } from 'fs'
+import * as path from 'path'
+// ESM only — CJS can use __dirname directly
+import { fileURLToPath } from 'url'
+const migrationFolder = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  './migrations',
+)
+
+// `db` is your Kysely<any> database instance
+const migrator = new Migrator({
+  db,
+  provider: new FileMigrationProvider({
+    fs,
+    path,
+    migrationFolder,
+  }),
+  // WARNING: Only enable in development. Disables timestamp-ordering
+  // validation, which can cause schema drift between environments.
+  // allowUnorderedMigrations: true,
+})
+
+const { error, results } = await migrator.migrateToLatest()
+
+results?.forEach((it) => {
+  if (it.status === 'Success') {
+    console.log(`migration "${it.migrationName}" executed successfully`)
+  } else if (it.status === 'Error') {
+    console.error(`failed to execute migration "${it.migrationName}"`)
+  }
+})
+
+if (error) {
+  console.error('migration failed', error)
+  process.exit(1)
+}
+```
+
+## Django (Python)
+
+### Workflow
+
+```bash
+# Generate migration from model changes
+python manage.py makemigrations
+
+# Apply migrations
+python manage.py migrate
+
+# Show migration status
+python manage.py showmigrations
+
+# Generate empty migration for custom SQL
+python manage.py makemigrations --empty app_name -n description
+```
+
+### Data Migration
+
+```python
+from django.db import migrations
+
+def backfill_display_names(apps, schema_editor):
+    User = apps.get_model("accounts", "User")
+    batch_size = 5000
+    users = User.objects.filter(display_name="")
+    while users.exists():
+        batch = list(users[:batch_size])
+        for user in batch:
+            user.display_name = user.username
+        User.objects.bulk_update(batch, ["display_name"], batch_size=batch_size)
+
+def reverse_backfill(apps, schema_editor):
+    pass  # Data migration, no reverse needed
+
+class Migration(migrations.Migration):
+    dependencies = [("accounts", "0015_add_display_name")]
+
+    operations = [
+        migrations.RunPython(backfill_display_names, reverse_backfill),
+    ]
+```
+
+### SeparateDatabaseAndState
+
+Remove a column from the Django model without dropping it from the database immediately:
+
+```python
+class Migration(migrations.Migration):
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.RemoveField(model_name="user", name="legacy_field"),
+            ],
+            database_operations=[],  # Don't touch the DB yet
+        ),
+    ]
+```
+
+## golang-migrate (Go)
+
+### Workflow
+
+```bash
+# Create migration pair
+migrate create -ext sql -dir migrations -seq add_user_avatar
+
+# Apply all pending migrations
+migrate -path migrations -database "$DATABASE_URL" up
+
+# Rollback last migration
+migrate -path migrations -database "$DATABASE_URL" down 1
+
+# Force version (fix dirty state)
+migrate -path migrations -database "$DATABASE_URL" force VERSION
+```
+
+### Migration Files
+
+```sql
+-- migrations/000003_add_user_avatar.up.sql
+ALTER TABLE users ADD COLUMN avatar_url TEXT;
+CREATE INDEX CONCURRENTLY idx_users_avatar ON users (avatar_url) WHERE avatar_url IS NOT NULL;
+
+-- migrations/000003_add_user_avatar.down.sql
+DROP INDEX IF EXISTS idx_users_avatar;
+ALTER TABLE users DROP COLUMN IF EXISTS avatar_url;
+```
+
+## Zero-Downtime Migration Strategy
+
+For critical production changes, follow the expand-contract pattern:
+
+```
+Phase 1: EXPAND
+  - Add new column/table (nullable or with default)
+  - Deploy: app writes to BOTH old and new
+  - Backfill existing data
+
+Phase 2: MIGRATE
+  - Deploy: app reads from NEW, writes to BOTH
+  - Verify data consistency
+
+Phase 3: CONTRACT
+  - Deploy: app only uses NEW
+  - Drop old column/table in separate migration
+```
+
+### Timeline Example
+
+```
+Day 1: Migration adds new_status column (nullable)
+Day 1: Deploy app v2 — writes to both status and new_status
+Day 2: Run backfill migration for existing rows
+Day 3: Deploy app v3 — reads from new_status only
+Day 7: Migration drops old status column
+```
+
+## Anti-Patterns
+
+| Anti-Pattern | Why It Fails | Better Approach |
+|-------------|-------------|-----------------|
+| Manual SQL in production | No audit trail, unrepeatable | Always use migration files |
+| Editing deployed migrations | Causes drift between environments | Create new migration instead |
+| NOT NULL without default | Locks table, rewrites all rows | Add nullable, backfill, then add constraint |
+| Inline index on large table | Blocks writes during build | CREATE INDEX CONCURRENTLY |
+| Schema + data in one migration | Hard to rollback, long transactions | Separate migrations |
+| Dropping column before removing code | Application errors on missing column | Remove code first, drop column next deploy |

--- a/.claude/skills/golang-patterns/SKILL.md
+++ b/.claude/skills/golang-patterns/SKILL.md
@@ -1,0 +1,674 @@
+---
+name: golang-patterns
+description: Idiomatic Go patterns, best practices, and conventions for building robust, efficient, and maintainable Go applications.
+origin: ECC
+---
+
+# Go Development Patterns
+
+Idiomatic Go patterns and best practices for building robust, efficient, and maintainable applications.
+
+## When to Activate
+
+- Writing new Go code
+- Reviewing Go code
+- Refactoring existing Go code
+- Designing Go packages/modules
+
+## Core Principles
+
+### 1. Simplicity and Clarity
+
+Go favors simplicity over cleverness. Code should be obvious and easy to read.
+
+```go
+// Good: Clear and direct
+func GetUser(id string) (*User, error) {
+    user, err := db.FindUser(id)
+    if err != nil {
+        return nil, fmt.Errorf("get user %s: %w", id, err)
+    }
+    return user, nil
+}
+
+// Bad: Overly clever
+func GetUser(id string) (*User, error) {
+    return func() (*User, error) {
+        if u, e := db.FindUser(id); e == nil {
+            return u, nil
+        } else {
+            return nil, e
+        }
+    }()
+}
+```
+
+### 2. Make the Zero Value Useful
+
+Design types so their zero value is immediately usable without initialization.
+
+```go
+// Good: Zero value is useful
+type Counter struct {
+    mu    sync.Mutex
+    count int // zero value is 0, ready to use
+}
+
+func (c *Counter) Inc() {
+    c.mu.Lock()
+    c.count++
+    c.mu.Unlock()
+}
+
+// Good: bytes.Buffer works with zero value
+var buf bytes.Buffer
+buf.WriteString("hello")
+
+// Bad: Requires initialization
+type BadCounter struct {
+    counts map[string]int // nil map will panic
+}
+```
+
+### 3. Accept Interfaces, Return Structs
+
+Functions should accept interface parameters and return concrete types.
+
+```go
+// Good: Accepts interface, returns concrete type
+func ProcessData(r io.Reader) (*Result, error) {
+    data, err := io.ReadAll(r)
+    if err != nil {
+        return nil, err
+    }
+    return &Result{Data: data}, nil
+}
+
+// Bad: Returns interface (hides implementation details unnecessarily)
+func ProcessData(r io.Reader) (io.Reader, error) {
+    // ...
+}
+```
+
+## Error Handling Patterns
+
+### Error Wrapping with Context
+
+```go
+// Good: Wrap errors with context
+func LoadConfig(path string) (*Config, error) {
+    data, err := os.ReadFile(path)
+    if err != nil {
+        return nil, fmt.Errorf("load config %s: %w", path, err)
+    }
+
+    var cfg Config
+    if err := json.Unmarshal(data, &cfg); err != nil {
+        return nil, fmt.Errorf("parse config %s: %w", path, err)
+    }
+
+    return &cfg, nil
+}
+```
+
+### Custom Error Types
+
+```go
+// Define domain-specific errors
+type ValidationError struct {
+    Field   string
+    Message string
+}
+
+func (e *ValidationError) Error() string {
+    return fmt.Sprintf("validation failed on %s: %s", e.Field, e.Message)
+}
+
+// Sentinel errors for common cases
+var (
+    ErrNotFound     = errors.New("resource not found")
+    ErrUnauthorized = errors.New("unauthorized")
+    ErrInvalidInput = errors.New("invalid input")
+)
+```
+
+### Error Checking with errors.Is and errors.As
+
+```go
+func HandleError(err error) {
+    // Check for specific error
+    if errors.Is(err, sql.ErrNoRows) {
+        log.Println("No records found")
+        return
+    }
+
+    // Check for error type
+    var validationErr *ValidationError
+    if errors.As(err, &validationErr) {
+        log.Printf("Validation error on field %s: %s",
+            validationErr.Field, validationErr.Message)
+        return
+    }
+
+    // Unknown error
+    log.Printf("Unexpected error: %v", err)
+}
+```
+
+### Never Ignore Errors
+
+```go
+// Bad: Ignoring error with blank identifier
+result, _ := doSomething()
+
+// Good: Handle or explicitly document why it's safe to ignore
+result, err := doSomething()
+if err != nil {
+    return err
+}
+
+// Acceptable: When error truly doesn't matter (rare)
+_ = writer.Close() // Best-effort cleanup, error logged elsewhere
+```
+
+## Concurrency Patterns
+
+### Worker Pool
+
+```go
+func WorkerPool(jobs <-chan Job, results chan<- Result, numWorkers int) {
+    var wg sync.WaitGroup
+
+    for i := 0; i < numWorkers; i++ {
+        wg.Add(1)
+        go func() {
+            defer wg.Done()
+            for job := range jobs {
+                results <- process(job)
+            }
+        }()
+    }
+
+    wg.Wait()
+    close(results)
+}
+```
+
+### Context for Cancellation and Timeouts
+
+```go
+func FetchWithTimeout(ctx context.Context, url string) ([]byte, error) {
+    ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+    defer cancel()
+
+    req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+    if err != nil {
+        return nil, fmt.Errorf("create request: %w", err)
+    }
+
+    resp, err := http.DefaultClient.Do(req)
+    if err != nil {
+        return nil, fmt.Errorf("fetch %s: %w", url, err)
+    }
+    defer resp.Body.Close()
+
+    return io.ReadAll(resp.Body)
+}
+```
+
+### Graceful Shutdown
+
+```go
+func GracefulShutdown(server *http.Server) {
+    quit := make(chan os.Signal, 1)
+    signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
+
+    <-quit
+    log.Println("Shutting down server...")
+
+    ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+    defer cancel()
+
+    if err := server.Shutdown(ctx); err != nil {
+        log.Fatalf("Server forced to shutdown: %v", err)
+    }
+
+    log.Println("Server exited")
+}
+```
+
+### errgroup for Coordinated Goroutines
+
+```go
+import "golang.org/x/sync/errgroup"
+
+func FetchAll(ctx context.Context, urls []string) ([][]byte, error) {
+    g, ctx := errgroup.WithContext(ctx)
+    results := make([][]byte, len(urls))
+
+    for i, url := range urls {
+        i, url := i, url // Capture loop variables
+        g.Go(func() error {
+            data, err := FetchWithTimeout(ctx, url)
+            if err != nil {
+                return err
+            }
+            results[i] = data
+            return nil
+        })
+    }
+
+    if err := g.Wait(); err != nil {
+        return nil, err
+    }
+    return results, nil
+}
+```
+
+### Avoiding Goroutine Leaks
+
+```go
+// Bad: Goroutine leak if context is cancelled
+func leakyFetch(ctx context.Context, url string) <-chan []byte {
+    ch := make(chan []byte)
+    go func() {
+        data, _ := fetch(url)
+        ch <- data // Blocks forever if no receiver
+    }()
+    return ch
+}
+
+// Good: Properly handles cancellation
+func safeFetch(ctx context.Context, url string) <-chan []byte {
+    ch := make(chan []byte, 1) // Buffered channel
+    go func() {
+        data, err := fetch(url)
+        if err != nil {
+            return
+        }
+        select {
+        case ch <- data:
+        case <-ctx.Done():
+        }
+    }()
+    return ch
+}
+```
+
+## Interface Design
+
+### Small, Focused Interfaces
+
+```go
+// Good: Single-method interfaces
+type Reader interface {
+    Read(p []byte) (n int, err error)
+}
+
+type Writer interface {
+    Write(p []byte) (n int, err error)
+}
+
+type Closer interface {
+    Close() error
+}
+
+// Compose interfaces as needed
+type ReadWriteCloser interface {
+    Reader
+    Writer
+    Closer
+}
+```
+
+### Define Interfaces Where They're Used
+
+```go
+// In the consumer package, not the provider
+package service
+
+// UserStore defines what this service needs
+type UserStore interface {
+    GetUser(id string) (*User, error)
+    SaveUser(user *User) error
+}
+
+type Service struct {
+    store UserStore
+}
+
+// Concrete implementation can be in another package
+// It doesn't need to know about this interface
+```
+
+### Optional Behavior with Type Assertions
+
+```go
+type Flusher interface {
+    Flush() error
+}
+
+func WriteAndFlush(w io.Writer, data []byte) error {
+    if _, err := w.Write(data); err != nil {
+        return err
+    }
+
+    // Flush if supported
+    if f, ok := w.(Flusher); ok {
+        return f.Flush()
+    }
+    return nil
+}
+```
+
+## Package Organization
+
+### Standard Project Layout
+
+```text
+myproject/
+├── cmd/
+│   └── myapp/
+│       └── main.go           # Entry point
+├── internal/
+│   ├── handler/              # HTTP handlers
+│   ├── service/              # Business logic
+│   ├── repository/           # Data access
+│   └── config/               # Configuration
+├── pkg/
+│   └── client/               # Public API client
+├── api/
+│   └── v1/                   # API definitions (proto, OpenAPI)
+├── testdata/                 # Test fixtures
+├── go.mod
+├── go.sum
+└── Makefile
+```
+
+### Package Naming
+
+```go
+// Good: Short, lowercase, no underscores
+package http
+package json
+package user
+
+// Bad: Verbose, mixed case, or redundant
+package httpHandler
+package json_parser
+package userService // Redundant 'Service' suffix
+```
+
+### Avoid Package-Level State
+
+```go
+// Bad: Global mutable state
+var db *sql.DB
+
+func init() {
+    db, _ = sql.Open("postgres", os.Getenv("DATABASE_URL"))
+}
+
+// Good: Dependency injection
+type Server struct {
+    db *sql.DB
+}
+
+func NewServer(db *sql.DB) *Server {
+    return &Server{db: db}
+}
+```
+
+## Struct Design
+
+### Functional Options Pattern
+
+```go
+type Server struct {
+    addr    string
+    timeout time.Duration
+    logger  *log.Logger
+}
+
+type Option func(*Server)
+
+func WithTimeout(d time.Duration) Option {
+    return func(s *Server) {
+        s.timeout = d
+    }
+}
+
+func WithLogger(l *log.Logger) Option {
+    return func(s *Server) {
+        s.logger = l
+    }
+}
+
+func NewServer(addr string, opts ...Option) *Server {
+    s := &Server{
+        addr:    addr,
+        timeout: 30 * time.Second, // default
+        logger:  log.Default(),    // default
+    }
+    for _, opt := range opts {
+        opt(s)
+    }
+    return s
+}
+
+// Usage
+server := NewServer(":8080",
+    WithTimeout(60*time.Second),
+    WithLogger(customLogger),
+)
+```
+
+### Embedding for Composition
+
+```go
+type Logger struct {
+    prefix string
+}
+
+func (l *Logger) Log(msg string) {
+    fmt.Printf("[%s] %s\n", l.prefix, msg)
+}
+
+type Server struct {
+    *Logger // Embedding - Server gets Log method
+    addr    string
+}
+
+func NewServer(addr string) *Server {
+    return &Server{
+        Logger: &Logger{prefix: "SERVER"},
+        addr:   addr,
+    }
+}
+
+// Usage
+s := NewServer(":8080")
+s.Log("Starting...") // Calls embedded Logger.Log
+```
+
+## Memory and Performance
+
+### Preallocate Slices When Size is Known
+
+```go
+// Bad: Grows slice multiple times
+func processItems(items []Item) []Result {
+    var results []Result
+    for _, item := range items {
+        results = append(results, process(item))
+    }
+    return results
+}
+
+// Good: Single allocation
+func processItems(items []Item) []Result {
+    results := make([]Result, 0, len(items))
+    for _, item := range items {
+        results = append(results, process(item))
+    }
+    return results
+}
+```
+
+### Use sync.Pool for Frequent Allocations
+
+```go
+var bufferPool = sync.Pool{
+    New: func() interface{} {
+        return new(bytes.Buffer)
+    },
+}
+
+func ProcessRequest(data []byte) []byte {
+    buf := bufferPool.Get().(*bytes.Buffer)
+    defer func() {
+        buf.Reset()
+        bufferPool.Put(buf)
+    }()
+
+    buf.Write(data)
+    // Process...
+    return buf.Bytes()
+}
+```
+
+### Avoid String Concatenation in Loops
+
+```go
+// Bad: Creates many string allocations
+func join(parts []string) string {
+    var result string
+    for _, p := range parts {
+        result += p + ","
+    }
+    return result
+}
+
+// Good: Single allocation with strings.Builder
+func join(parts []string) string {
+    var sb strings.Builder
+    for i, p := range parts {
+        if i > 0 {
+            sb.WriteString(",")
+        }
+        sb.WriteString(p)
+    }
+    return sb.String()
+}
+
+// Best: Use standard library
+func join(parts []string) string {
+    return strings.Join(parts, ",")
+}
+```
+
+## Go Tooling Integration
+
+### Essential Commands
+
+```bash
+# Build and run
+go build ./...
+go run ./cmd/myapp
+
+# Testing
+go test ./...
+go test -race ./...
+go test -cover ./...
+
+# Static analysis
+go vet ./...
+staticcheck ./...
+golangci-lint run
+
+# Module management
+go mod tidy
+go mod verify
+
+# Formatting
+gofmt -w .
+goimports -w .
+```
+
+### Recommended Linter Configuration (.golangci.yml)
+
+```yaml
+linters:
+  enable:
+    - errcheck
+    - gosimple
+    - govet
+    - ineffassign
+    - staticcheck
+    - unused
+    - gofmt
+    - goimports
+    - misspell
+    - unconvert
+    - unparam
+
+linters-settings:
+  errcheck:
+    check-type-assertions: true
+  govet:
+    check-shadowing: true
+
+issues:
+  exclude-use-default: false
+```
+
+## Quick Reference: Go Idioms
+
+| Idiom | Description |
+|-------|-------------|
+| Accept interfaces, return structs | Functions accept interface params, return concrete types |
+| Errors are values | Treat errors as first-class values, not exceptions |
+| Don't communicate by sharing memory | Use channels for coordination between goroutines |
+| Make the zero value useful | Types should work without explicit initialization |
+| A little copying is better than a little dependency | Avoid unnecessary external dependencies |
+| Clear is better than clever | Prioritize readability over cleverness |
+| gofmt is no one's favorite but everyone's friend | Always format with gofmt/goimports |
+| Return early | Handle errors first, keep happy path unindented |
+
+## Anti-Patterns to Avoid
+
+```go
+// Bad: Naked returns in long functions
+func process() (result int, err error) {
+    // ... 50 lines ...
+    return // What is being returned?
+}
+
+// Bad: Using panic for control flow
+func GetUser(id string) *User {
+    user, err := db.Find(id)
+    if err != nil {
+        panic(err) // Don't do this
+    }
+    return user
+}
+
+// Bad: Passing context in struct
+type Request struct {
+    ctx context.Context // Context should be first param
+    ID  string
+}
+
+// Good: Context as first parameter
+func ProcessRequest(ctx context.Context, id string) error {
+    // ...
+}
+
+// Bad: Mixing value and pointer receivers
+type Counter struct{ n int }
+func (c Counter) Value() int { return c.n }    // Value receiver
+func (c *Counter) Increment() { c.n++ }        // Pointer receiver
+// Pick one style and be consistent
+```
+
+**Remember**: Go code should be boring in the best way - predictable, consistent, and easy to understand. When in doubt, keep it simple.

--- a/.claude/skills/golang-testing/SKILL.md
+++ b/.claude/skills/golang-testing/SKILL.md
@@ -1,0 +1,720 @@
+---
+name: golang-testing
+description: Go testing patterns including table-driven tests, subtests, benchmarks, fuzzing, and test coverage. Follows TDD methodology with idiomatic Go practices.
+origin: ECC
+---
+
+# Go Testing Patterns
+
+Comprehensive Go testing patterns for writing reliable, maintainable tests following TDD methodology.
+
+## When to Activate
+
+- Writing new Go functions or methods
+- Adding test coverage to existing code
+- Creating benchmarks for performance-critical code
+- Implementing fuzz tests for input validation
+- Following TDD workflow in Go projects
+
+## TDD Workflow for Go
+
+### The RED-GREEN-REFACTOR Cycle
+
+```
+RED     → Write a failing test first
+GREEN   → Write minimal code to pass the test
+REFACTOR → Improve code while keeping tests green
+REPEAT  → Continue with next requirement
+```
+
+### Step-by-Step TDD in Go
+
+```go
+// Step 1: Define the interface/signature
+// calculator.go
+package calculator
+
+func Add(a, b int) int {
+    panic("not implemented") // Placeholder
+}
+
+// Step 2: Write failing test (RED)
+// calculator_test.go
+package calculator
+
+import "testing"
+
+func TestAdd(t *testing.T) {
+    got := Add(2, 3)
+    want := 5
+    if got != want {
+        t.Errorf("Add(2, 3) = %d; want %d", got, want)
+    }
+}
+
+// Step 3: Run test - verify FAIL
+// $ go test
+// --- FAIL: TestAdd (0.00s)
+// panic: not implemented
+
+// Step 4: Implement minimal code (GREEN)
+func Add(a, b int) int {
+    return a + b
+}
+
+// Step 5: Run test - verify PASS
+// $ go test
+// PASS
+
+// Step 6: Refactor if needed, verify tests still pass
+```
+
+## Table-Driven Tests
+
+The standard pattern for Go tests. Enables comprehensive coverage with minimal code.
+
+```go
+func TestAdd(t *testing.T) {
+    tests := []struct {
+        name     string
+        a, b     int
+        expected int
+    }{
+        {"positive numbers", 2, 3, 5},
+        {"negative numbers", -1, -2, -3},
+        {"zero values", 0, 0, 0},
+        {"mixed signs", -1, 1, 0},
+        {"large numbers", 1000000, 2000000, 3000000},
+    }
+
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            got := Add(tt.a, tt.b)
+            if got != tt.expected {
+                t.Errorf("Add(%d, %d) = %d; want %d",
+                    tt.a, tt.b, got, tt.expected)
+            }
+        })
+    }
+}
+```
+
+### Table-Driven Tests with Error Cases
+
+```go
+func TestParseConfig(t *testing.T) {
+    tests := []struct {
+        name    string
+        input   string
+        want    *Config
+        wantErr bool
+    }{
+        {
+            name:  "valid config",
+            input: `{"host": "localhost", "port": 8080}`,
+            want:  &Config{Host: "localhost", Port: 8080},
+        },
+        {
+            name:    "invalid JSON",
+            input:   `{invalid}`,
+            wantErr: true,
+        },
+        {
+            name:    "empty input",
+            input:   "",
+            wantErr: true,
+        },
+        {
+            name:  "minimal config",
+            input: `{}`,
+            want:  &Config{}, // Zero value config
+        },
+    }
+
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            got, err := ParseConfig(tt.input)
+
+            if tt.wantErr {
+                if err == nil {
+                    t.Error("expected error, got nil")
+                }
+                return
+            }
+
+            if err != nil {
+                t.Fatalf("unexpected error: %v", err)
+            }
+
+            if !reflect.DeepEqual(got, tt.want) {
+                t.Errorf("got %+v; want %+v", got, tt.want)
+            }
+        })
+    }
+}
+```
+
+## Subtests and Sub-benchmarks
+
+### Organizing Related Tests
+
+```go
+func TestUser(t *testing.T) {
+    // Setup shared by all subtests
+    db := setupTestDB(t)
+
+    t.Run("Create", func(t *testing.T) {
+        user := &User{Name: "Alice"}
+        err := db.CreateUser(user)
+        if err != nil {
+            t.Fatalf("CreateUser failed: %v", err)
+        }
+        if user.ID == "" {
+            t.Error("expected user ID to be set")
+        }
+    })
+
+    t.Run("Get", func(t *testing.T) {
+        user, err := db.GetUser("alice-id")
+        if err != nil {
+            t.Fatalf("GetUser failed: %v", err)
+        }
+        if user.Name != "Alice" {
+            t.Errorf("got name %q; want %q", user.Name, "Alice")
+        }
+    })
+
+    t.Run("Update", func(t *testing.T) {
+        // ...
+    })
+
+    t.Run("Delete", func(t *testing.T) {
+        // ...
+    })
+}
+```
+
+### Parallel Subtests
+
+```go
+func TestParallel(t *testing.T) {
+    tests := []struct {
+        name  string
+        input string
+    }{
+        {"case1", "input1"},
+        {"case2", "input2"},
+        {"case3", "input3"},
+    }
+
+    for _, tt := range tests {
+        tt := tt // Capture range variable
+        t.Run(tt.name, func(t *testing.T) {
+            t.Parallel() // Run subtests in parallel
+            result := Process(tt.input)
+            // assertions...
+            _ = result
+        })
+    }
+}
+```
+
+## Test Helpers
+
+### Helper Functions
+
+```go
+func setupTestDB(t *testing.T) *sql.DB {
+    t.Helper() // Marks this as a helper function
+
+    db, err := sql.Open("sqlite3", ":memory:")
+    if err != nil {
+        t.Fatalf("failed to open database: %v", err)
+    }
+
+    // Cleanup when test finishes
+    t.Cleanup(func() {
+        db.Close()
+    })
+
+    // Run migrations
+    if _, err := db.Exec(schema); err != nil {
+        t.Fatalf("failed to create schema: %v", err)
+    }
+
+    return db
+}
+
+func assertNoError(t *testing.T, err error) {
+    t.Helper()
+    if err != nil {
+        t.Fatalf("unexpected error: %v", err)
+    }
+}
+
+func assertEqual[T comparable](t *testing.T, got, want T) {
+    t.Helper()
+    if got != want {
+        t.Errorf("got %v; want %v", got, want)
+    }
+}
+```
+
+### Temporary Files and Directories
+
+```go
+func TestFileProcessing(t *testing.T) {
+    // Create temp directory - automatically cleaned up
+    tmpDir := t.TempDir()
+
+    // Create test file
+    testFile := filepath.Join(tmpDir, "test.txt")
+    err := os.WriteFile(testFile, []byte("test content"), 0644)
+    if err != nil {
+        t.Fatalf("failed to create test file: %v", err)
+    }
+
+    // Run test
+    result, err := ProcessFile(testFile)
+    if err != nil {
+        t.Fatalf("ProcessFile failed: %v", err)
+    }
+
+    // Assert...
+    _ = result
+}
+```
+
+## Golden Files
+
+Testing against expected output files stored in `testdata/`.
+
+```go
+var update = flag.Bool("update", false, "update golden files")
+
+func TestRender(t *testing.T) {
+    tests := []struct {
+        name  string
+        input Template
+    }{
+        {"simple", Template{Name: "test"}},
+        {"complex", Template{Name: "test", Items: []string{"a", "b"}}},
+    }
+
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            got := Render(tt.input)
+
+            golden := filepath.Join("testdata", tt.name+".golden")
+
+            if *update {
+                // Update golden file: go test -update
+                err := os.WriteFile(golden, got, 0644)
+                if err != nil {
+                    t.Fatalf("failed to update golden file: %v", err)
+                }
+            }
+
+            want, err := os.ReadFile(golden)
+            if err != nil {
+                t.Fatalf("failed to read golden file: %v", err)
+            }
+
+            if !bytes.Equal(got, want) {
+                t.Errorf("output mismatch:\ngot:\n%s\nwant:\n%s", got, want)
+            }
+        })
+    }
+}
+```
+
+## Mocking with Interfaces
+
+### Interface-Based Mocking
+
+```go
+// Define interface for dependencies
+type UserRepository interface {
+    GetUser(id string) (*User, error)
+    SaveUser(user *User) error
+}
+
+// Production implementation
+type PostgresUserRepository struct {
+    db *sql.DB
+}
+
+func (r *PostgresUserRepository) GetUser(id string) (*User, error) {
+    // Real database query
+}
+
+// Mock implementation for tests
+type MockUserRepository struct {
+    GetUserFunc  func(id string) (*User, error)
+    SaveUserFunc func(user *User) error
+}
+
+func (m *MockUserRepository) GetUser(id string) (*User, error) {
+    return m.GetUserFunc(id)
+}
+
+func (m *MockUserRepository) SaveUser(user *User) error {
+    return m.SaveUserFunc(user)
+}
+
+// Test using mock
+func TestUserService(t *testing.T) {
+    mock := &MockUserRepository{
+        GetUserFunc: func(id string) (*User, error) {
+            if id == "123" {
+                return &User{ID: "123", Name: "Alice"}, nil
+            }
+            return nil, ErrNotFound
+        },
+    }
+
+    service := NewUserService(mock)
+
+    user, err := service.GetUserProfile("123")
+    if err != nil {
+        t.Fatalf("unexpected error: %v", err)
+    }
+    if user.Name != "Alice" {
+        t.Errorf("got name %q; want %q", user.Name, "Alice")
+    }
+}
+```
+
+## Benchmarks
+
+### Basic Benchmarks
+
+```go
+func BenchmarkProcess(b *testing.B) {
+    data := generateTestData(1000)
+    b.ResetTimer() // Don't count setup time
+
+    for i := 0; i < b.N; i++ {
+        Process(data)
+    }
+}
+
+// Run: go test -bench=BenchmarkProcess -benchmem
+// Output: BenchmarkProcess-8   10000   105234 ns/op   4096 B/op   10 allocs/op
+```
+
+### Benchmark with Different Sizes
+
+```go
+func BenchmarkSort(b *testing.B) {
+    sizes := []int{100, 1000, 10000, 100000}
+
+    for _, size := range sizes {
+        b.Run(fmt.Sprintf("size=%d", size), func(b *testing.B) {
+            data := generateRandomSlice(size)
+            b.ResetTimer()
+
+            for i := 0; i < b.N; i++ {
+                // Make a copy to avoid sorting already sorted data
+                tmp := make([]int, len(data))
+                copy(tmp, data)
+                sort.Ints(tmp)
+            }
+        })
+    }
+}
+```
+
+### Memory Allocation Benchmarks
+
+```go
+func BenchmarkStringConcat(b *testing.B) {
+    parts := []string{"hello", "world", "foo", "bar", "baz"}
+
+    b.Run("plus", func(b *testing.B) {
+        for i := 0; i < b.N; i++ {
+            var s string
+            for _, p := range parts {
+                s += p
+            }
+            _ = s
+        }
+    })
+
+    b.Run("builder", func(b *testing.B) {
+        for i := 0; i < b.N; i++ {
+            var sb strings.Builder
+            for _, p := range parts {
+                sb.WriteString(p)
+            }
+            _ = sb.String()
+        }
+    })
+
+    b.Run("join", func(b *testing.B) {
+        for i := 0; i < b.N; i++ {
+            _ = strings.Join(parts, "")
+        }
+    })
+}
+```
+
+## Fuzzing (Go 1.18+)
+
+### Basic Fuzz Test
+
+```go
+func FuzzParseJSON(f *testing.F) {
+    // Add seed corpus
+    f.Add(`{"name": "test"}`)
+    f.Add(`{"count": 123}`)
+    f.Add(`[]`)
+    f.Add(`""`)
+
+    f.Fuzz(func(t *testing.T, input string) {
+        var result map[string]interface{}
+        err := json.Unmarshal([]byte(input), &result)
+
+        if err != nil {
+            // Invalid JSON is expected for random input
+            return
+        }
+
+        // If parsing succeeded, re-encoding should work
+        _, err = json.Marshal(result)
+        if err != nil {
+            t.Errorf("Marshal failed after successful Unmarshal: %v", err)
+        }
+    })
+}
+
+// Run: go test -fuzz=FuzzParseJSON -fuzztime=30s
+```
+
+### Fuzz Test with Multiple Inputs
+
+```go
+func FuzzCompare(f *testing.F) {
+    f.Add("hello", "world")
+    f.Add("", "")
+    f.Add("abc", "abc")
+
+    f.Fuzz(func(t *testing.T, a, b string) {
+        result := Compare(a, b)
+
+        // Property: Compare(a, a) should always equal 0
+        if a == b && result != 0 {
+            t.Errorf("Compare(%q, %q) = %d; want 0", a, b, result)
+        }
+
+        // Property: Compare(a, b) and Compare(b, a) should have opposite signs
+        reverse := Compare(b, a)
+        if (result > 0 && reverse >= 0) || (result < 0 && reverse <= 0) {
+            if result != 0 || reverse != 0 {
+                t.Errorf("Compare(%q, %q) = %d, Compare(%q, %q) = %d; inconsistent",
+                    a, b, result, b, a, reverse)
+            }
+        }
+    })
+}
+```
+
+## Test Coverage
+
+### Running Coverage
+
+```bash
+# Basic coverage
+go test -cover ./...
+
+# Generate coverage profile
+go test -coverprofile=coverage.out ./...
+
+# View coverage in browser
+go tool cover -html=coverage.out
+
+# View coverage by function
+go tool cover -func=coverage.out
+
+# Coverage with race detection
+go test -race -coverprofile=coverage.out ./...
+```
+
+### Coverage Targets
+
+| Code Type | Target |
+|-----------|--------|
+| Critical business logic | 100% |
+| Public APIs | 90%+ |
+| General code | 80%+ |
+| Generated code | Exclude |
+
+### Excluding Generated Code from Coverage
+
+```go
+//go:generate mockgen -source=interface.go -destination=mock_interface.go
+
+// In coverage profile, exclude with build tags:
+// go test -cover -tags=!generate ./...
+```
+
+## HTTP Handler Testing
+
+```go
+func TestHealthHandler(t *testing.T) {
+    // Create request
+    req := httptest.NewRequest(http.MethodGet, "/health", nil)
+    w := httptest.NewRecorder()
+
+    // Call handler
+    HealthHandler(w, req)
+
+    // Check response
+    resp := w.Result()
+    defer resp.Body.Close()
+
+    if resp.StatusCode != http.StatusOK {
+        t.Errorf("got status %d; want %d", resp.StatusCode, http.StatusOK)
+    }
+
+    body, _ := io.ReadAll(resp.Body)
+    if string(body) != "OK" {
+        t.Errorf("got body %q; want %q", body, "OK")
+    }
+}
+
+func TestAPIHandler(t *testing.T) {
+    tests := []struct {
+        name       string
+        method     string
+        path       string
+        body       string
+        wantStatus int
+        wantBody   string
+    }{
+        {
+            name:       "get user",
+            method:     http.MethodGet,
+            path:       "/users/123",
+            wantStatus: http.StatusOK,
+            wantBody:   `{"id":"123","name":"Alice"}`,
+        },
+        {
+            name:       "not found",
+            method:     http.MethodGet,
+            path:       "/users/999",
+            wantStatus: http.StatusNotFound,
+        },
+        {
+            name:       "create user",
+            method:     http.MethodPost,
+            path:       "/users",
+            body:       `{"name":"Bob"}`,
+            wantStatus: http.StatusCreated,
+        },
+    }
+
+    handler := NewAPIHandler()
+
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            var body io.Reader
+            if tt.body != "" {
+                body = strings.NewReader(tt.body)
+            }
+
+            req := httptest.NewRequest(tt.method, tt.path, body)
+            req.Header.Set("Content-Type", "application/json")
+            w := httptest.NewRecorder()
+
+            handler.ServeHTTP(w, req)
+
+            if w.Code != tt.wantStatus {
+                t.Errorf("got status %d; want %d", w.Code, tt.wantStatus)
+            }
+
+            if tt.wantBody != "" && w.Body.String() != tt.wantBody {
+                t.Errorf("got body %q; want %q", w.Body.String(), tt.wantBody)
+            }
+        })
+    }
+}
+```
+
+## Testing Commands
+
+```bash
+# Run all tests
+go test ./...
+
+# Run tests with verbose output
+go test -v ./...
+
+# Run specific test
+go test -run TestAdd ./...
+
+# Run tests matching pattern
+go test -run "TestUser/Create" ./...
+
+# Run tests with race detector
+go test -race ./...
+
+# Run tests with coverage
+go test -cover -coverprofile=coverage.out ./...
+
+# Run short tests only
+go test -short ./...
+
+# Run tests with timeout
+go test -timeout 30s ./...
+
+# Run benchmarks
+go test -bench=. -benchmem ./...
+
+# Run fuzzing
+go test -fuzz=FuzzParse -fuzztime=30s ./...
+
+# Count test runs (for flaky test detection)
+go test -count=10 ./...
+```
+
+## Best Practices
+
+**DO:**
+- Write tests FIRST (TDD)
+- Use table-driven tests for comprehensive coverage
+- Test behavior, not implementation
+- Use `t.Helper()` in helper functions
+- Use `t.Parallel()` for independent tests
+- Clean up resources with `t.Cleanup()`
+- Use meaningful test names that describe the scenario
+
+**DON'T:**
+- Test private functions directly (test through public API)
+- Use `time.Sleep()` in tests (use channels or conditions)
+- Ignore flaky tests (fix or remove them)
+- Mock everything (prefer integration tests when possible)
+- Skip error path testing
+
+## Integration with CI/CD
+
+```yaml
+# GitHub Actions example
+test:
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-go@v5
+      with:
+        go-version: '1.22'
+
+    - name: Run tests
+      run: go test -race -coverprofile=coverage.out ./...
+
+    - name: Check coverage
+      run: |
+        go tool cover -func=coverage.out | grep total | awk '{print $3}' | \
+        awk -F'%' '{if ($1 < 80) exit 1}'
+```
+
+**Remember**: Tests are documentation. They show how your code is meant to be used. Write them clearly and keep them up to date.

--- a/.claude/skills/parallel-execution-optimizer/SKILL.md
+++ b/.claude/skills/parallel-execution-optimizer/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: parallel-execution-optimizer
+description: Use when the user wants a task done much faster through parallel work, concurrent agents, batched tool calls, isolated worktrees, or many independent verification lanes without losing correctness.
+origin: ECC
+tools: Read, Write, Edit, Bash, Grep, Glob
+---
+
+# Parallel Execution Optimizer
+
+Use this skill when speed comes from doing independent work at the same time:
+repo inspection, file reads, API checks, browser checks, build/test lanes,
+deploy readbacks, or multi-worktree implementation passes.
+
+## Core Pattern
+
+Turn urgency into a dependency graph before acting.
+
+1. Define the objective and done signal.
+2. Split work into lanes.
+3. Mark each lane as parallel, sequential, or gated.
+4. Run independent reads/checks together.
+5. Keep writes isolated by file, worktree, branch, service, or dataset.
+6. Merge only after evidence shows the lanes are compatible.
+7. End with a verification table, not a vague speed claim.
+
+## Lane Matrix
+
+Before a large push, write a compact matrix:
+
+```text
+Lane | Can run in parallel? | Write surface | Risk | Verification
+Repo scan | yes | none | low | rg/git status outputs
+Backend patch | maybe | src/api | medium | unit tests
+Frontend patch | maybe | app/components | medium | browser screenshot
+Deploy readback | after build | remote service | high | live URL + logs
+```
+
+Only run lanes in parallel when their write surfaces do not collide.
+
+## Execution Rules
+
+- Batch file reads, searches, status checks, and metadata queries.
+- Use isolated worktrees for large unrelated implementation lanes.
+- Start long-running tests, builds, backfills, and deploys in separate sessions,
+  then poll them deliberately.
+- If a lane discovers a blocker that changes the plan, pause dependent lanes
+  and update the matrix.
+- Never let a background process outlive the turn unless the user explicitly
+  asked for a continuing service.
+- Do not parallelize destructive commands, migrations, writes to the same table,
+  or live customer-impacting deploys without an explicit gate.
+
+## Output Shape
+
+Use this when reporting:
+
+```text
+Parallel execution result:
+- Lanes run: 5
+- Lanes completed: 4
+- Blocked lane: deploy readback, waiting on DNS propagation
+- Fast path found: batched repo scan + focused tests
+- Verification: lint pass, unit pass, live smoke pass
+```
+
+## Failure Modes
+
+- More concurrency that creates conflicting edits.
+- Benchmarking the tool instead of the task.
+- Treating "fast" as done before correctness is proven.
+- Forgetting to poll running sessions.
+- Hiding skipped checks behind a success summary.

--- a/.claude/skills/recursive-decision-ledger/SKILL.md
+++ b/.claude/skills/recursive-decision-ledger/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: recursive-decision-ledger
+description: Use when the user asks for repeated rollouts, marked decision processes, high-dimensional search, stochastic optimization, local-optima exploration, ensemble comparison, or recursive reasoning with a visible evidence trail.
+origin: ECC
+tools: Read, Write, Edit, Bash, Grep, Glob
+---
+
+# Recursive Decision Ledger
+
+Use this skill when the user is trying to force deeper computation through
+repeated rollouts or "Prime Gauss" style recursive prompting. Preserve the useful
+part: repeated trials, prior memory, fresh information, and explicit marks.
+Remove the unsafe part: pretending the loop proves certainty.
+
+## Ledger Contract
+
+Every rollout should record:
+
+- rollout id and timestamp;
+- prior accepted winner and prior watchlist;
+- fresh information ingested;
+- search space size;
+- model families or heuristics used;
+- trial count and effective trial count;
+- top candidates;
+- decision marks;
+- coherence marks against the prior ledger;
+- promotion gate result.
+
+Prefer JSONL for append-only ledgers and Markdown for human summaries.
+
+## Rollout Loop
+
+1. Load the prior ledger.
+2. Capture new information at time-step zero.
+3. Run the bounded search.
+4. Mark each candidate: accept, watch, reject, decay watch, or needs replay.
+5. Compare winners against prior winners and latest marked rollout.
+6. Downgrade candidates when drift, tail risk, stale data, or failed replay
+   invalidates the previous mark.
+7. Append artifacts before summarizing.
+
+## Coherence Mark
+
+Include a compact coherence mark:
+
+```text
+Ensemble matches prior winner: true
+Recursive matches prior winner: false
+Latest rollout match: true
+Live promotion allowed: false
+Reason: replay and freshness gates not satisfied
+```
+
+## Promotion Rules
+
+For trading, capital allocation, production deploys, migrations, or destructive
+ops, recursive confidence is not approval.
+
+Default to paper, dry-run, read-only, preview, or staged mode unless the user
+explicitly approves the live action and the repo/service gate supports it.
+
+Promote only when:
+
+- the candidate beats the prior accepted winner on the chosen metric;
+- correctness and replay checks pass;
+- risk limits are explicit;
+- the evidence is durable;
+- the user has approved the live step when needed.
+
+## Summary Shape
+
+Lead with the decision, not the drama:
+
+```text
+Rollout 15 complete. The prior winner still holds, but edge deteriorated 17%.
+Status: watch, not live. Next gate: 20 replay fills with fresh orderbook age
+below threshold.
+```

--- a/.claude/skills/security-review/SKILL.md
+++ b/.claude/skills/security-review/SKILL.md
@@ -1,0 +1,503 @@
+---
+name: security-review
+description: Use this skill when adding authentication, handling user input, working with secrets, creating API endpoints, or implementing payment/sensitive features. Provides comprehensive security checklist and patterns.
+origin: ECC
+---
+
+# Security Review Skill
+
+This skill ensures all code follows security best practices and identifies potential vulnerabilities.
+
+## When to Activate
+
+- Implementing authentication or authorization
+- Handling user input or file uploads
+- Creating new API endpoints
+- Working with secrets or credentials
+- Implementing payment features
+- Storing or transmitting sensitive data
+- Integrating third-party APIs
+
+## Security Checklist
+
+### 1. Secrets Management
+
+#### FAIL: NEVER Do This
+```typescript
+const apiKey = "sk-proj-xxxxx"  // Hardcoded secret
+const dbPassword = "password123" // In source code
+```
+
+#### PASS: ALWAYS Do This
+```typescript
+const apiKey = process.env.OPENAI_API_KEY
+const dbUrl = process.env.DATABASE_URL
+
+// Verify secrets exist
+if (!apiKey) {
+  throw new Error('OPENAI_API_KEY not configured')
+}
+```
+
+#### Verification Steps
+- [ ] No hardcoded API keys, tokens, or passwords
+- [ ] All secrets in environment variables
+- [ ] `.env.local` in .gitignore
+- [ ] No secrets in git history
+- [ ] Production secrets in hosting platform (Vercel, Railway)
+
+### 2. Input Validation
+
+#### Always Validate User Input
+```typescript
+import { z } from 'zod'
+
+// Define validation schema
+const CreateUserSchema = z.object({
+  email: z.string().email(),
+  name: z.string().min(1).max(100),
+  age: z.number().int().min(0).max(150)
+})
+
+// Validate before processing
+export async function createUser(input: unknown) {
+  try {
+    const validated = CreateUserSchema.parse(input)
+    return await db.users.create(validated)
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return { success: false, errors: error.errors }
+    }
+    throw error
+  }
+}
+```
+
+#### File Upload Validation
+```typescript
+function validateFileUpload(file: File) {
+  // Size check (5MB max)
+  const maxSize = 5 * 1024 * 1024
+  if (file.size > maxSize) {
+    throw new Error('File too large (max 5MB)')
+  }
+
+  // Type check
+  const allowedTypes = ['image/jpeg', 'image/png', 'image/gif']
+  if (!allowedTypes.includes(file.type)) {
+    throw new Error('Invalid file type')
+  }
+
+  // Extension check
+  const allowedExtensions = ['.jpg', '.jpeg', '.png', '.gif']
+  const extension = file.name.toLowerCase().match(/\.[^.]+$/)?.[0]
+  if (!extension || !allowedExtensions.includes(extension)) {
+    throw new Error('Invalid file extension')
+  }
+
+  return true
+}
+```
+
+#### Verification Steps
+- [ ] All user inputs validated with schemas
+- [ ] File uploads restricted (size, type, extension)
+- [ ] No direct use of user input in queries
+- [ ] Whitelist validation (not blacklist)
+- [ ] Error messages don't leak sensitive info
+
+### 3. SQL Injection Prevention
+
+#### FAIL: NEVER Concatenate SQL
+```typescript
+// DANGEROUS - SQL Injection vulnerability
+const query = `SELECT * FROM users WHERE email = '${userEmail}'`
+await db.query(query)
+```
+
+#### PASS: ALWAYS Use Parameterized Queries
+```typescript
+// Safe - parameterized query
+const { data } = await supabase
+  .from('users')
+  .select('*')
+  .eq('email', userEmail)
+
+// Or with raw SQL
+await db.query(
+  'SELECT * FROM users WHERE email = $1',
+  [userEmail]
+)
+```
+
+#### Verification Steps
+- [ ] All database queries use parameterized queries
+- [ ] No string concatenation in SQL
+- [ ] ORM/query builder used correctly
+- [ ] Supabase queries properly sanitized
+
+### 4. Authentication & Authorization
+
+#### JWT Token Handling
+```typescript
+// FAIL: WRONG: localStorage (vulnerable to XSS)
+localStorage.setItem('token', token)
+
+// PASS: CORRECT: httpOnly cookies
+res.setHeader('Set-Cookie',
+  `token=${token}; HttpOnly; Secure; SameSite=Strict; Max-Age=3600`)
+```
+
+#### Authorization Checks
+```typescript
+export async function deleteUser(userId: string, requesterId: string) {
+  // ALWAYS verify authorization first
+  const requester = await db.users.findUnique({
+    where: { id: requesterId }
+  })
+
+  if (requester.role !== 'admin') {
+    return NextResponse.json(
+      { error: 'Unauthorized' },
+      { status: 403 }
+    )
+  }
+
+  // Proceed with deletion
+  await db.users.delete({ where: { id: userId } })
+}
+```
+
+#### Row Level Security (Supabase)
+```sql
+-- Enable RLS on all tables
+ALTER TABLE users ENABLE ROW LEVEL SECURITY;
+
+-- Users can only view their own data
+CREATE POLICY "Users view own data"
+  ON users FOR SELECT
+  USING (auth.uid() = id);
+
+-- Users can only update their own data
+CREATE POLICY "Users update own data"
+  ON users FOR UPDATE
+  USING (auth.uid() = id);
+```
+
+#### Verification Steps
+- [ ] Tokens stored in httpOnly cookies (not localStorage)
+- [ ] Authorization checks before sensitive operations
+- [ ] Row Level Security enabled in Supabase
+- [ ] Role-based access control implemented
+- [ ] Session management secure
+
+### 5. XSS Prevention
+
+#### Sanitize HTML
+```typescript
+import DOMPurify from 'isomorphic-dompurify'
+
+// ALWAYS sanitize user-provided HTML
+function renderUserContent(html: string) {
+  const clean = DOMPurify.sanitize(html, {
+    ALLOWED_TAGS: ['b', 'i', 'em', 'strong', 'p'],
+    ALLOWED_ATTR: []
+  })
+  return <div dangerouslySetInnerHTML={{ __html: clean }} />
+}
+```
+
+#### Content Security Policy
+
+Start strict and loosen only with a documented removal plan. Do not default to
+`'unsafe-inline'` or `'unsafe-eval'`; they neutralize much of CSP's protection
+and should be treated as temporary compatibility debt.
+
+```typescript
+// next.config.js
+const securityHeaders = [
+  {
+    key: 'Content-Security-Policy',
+    value: `
+      default-src 'self';
+      base-uri 'self';
+      object-src 'none';
+      frame-ancestors 'none';
+      script-src 'self';
+      style-src 'self';
+      img-src 'self' data: https:;
+      font-src 'self';
+      connect-src 'self' https://api.example.com;
+    `.replace(/\s{2,}/g, ' ').trim()
+  }
+]
+```
+
+#### Verification Steps
+- [ ] User-provided HTML sanitized
+- [ ] CSP headers configured
+- [ ] No unvalidated dynamic content rendering
+- [ ] React's built-in XSS protection used
+
+### 6. CSRF Protection
+
+#### CSRF Tokens
+```typescript
+import { csrf } from '@/lib/csrf'
+
+export async function POST(request: Request) {
+  const token = request.headers.get('X-CSRF-Token')
+
+  if (!csrf.verify(token)) {
+    return NextResponse.json(
+      { error: 'Invalid CSRF token' },
+      { status: 403 }
+    )
+  }
+
+  // Process request
+}
+```
+
+#### SameSite Cookies
+```typescript
+res.setHeader('Set-Cookie',
+  `session=${sessionId}; HttpOnly; Secure; SameSite=Strict`)
+```
+
+#### Verification Steps
+- [ ] CSRF tokens on state-changing operations
+- [ ] SameSite=Strict on all cookies
+- [ ] Double-submit cookie pattern implemented
+
+### 7. Rate Limiting
+
+#### API Rate Limiting
+```typescript
+import rateLimit from 'express-rate-limit'
+
+const limiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // 100 requests per window
+  message: 'Too many requests'
+})
+
+// Apply to routes
+app.use('/api/', limiter)
+```
+
+#### Expensive Operations
+```typescript
+// Aggressive rate limiting for searches
+const searchLimiter = rateLimit({
+  windowMs: 60 * 1000, // 1 minute
+  max: 10, // 10 requests per minute
+  message: 'Too many search requests'
+})
+
+app.use('/api/search', searchLimiter)
+```
+
+#### Verification Steps
+- [ ] Rate limiting on all API endpoints
+- [ ] Stricter limits on expensive operations
+- [ ] IP-based rate limiting
+- [ ] User-based rate limiting (authenticated)
+
+### 8. Sensitive Data Exposure
+
+#### Logging
+```typescript
+// FAIL: WRONG: Logging sensitive data
+console.log('User login:', { email, password })
+console.log('Payment:', { cardNumber, cvv })
+
+// PASS: CORRECT: Redact sensitive data
+console.log('User login:', { email, userId })
+console.log('Payment:', { last4: card.last4, userId })
+```
+
+#### Error Messages
+```typescript
+// FAIL: WRONG: Exposing internal details
+catch (error) {
+  return NextResponse.json(
+    { error: error.message, stack: error.stack },
+    { status: 500 }
+  )
+}
+
+// PASS: CORRECT: Generic error messages
+catch (error) {
+  console.error('Internal error:', error)
+  return NextResponse.json(
+    { error: 'An error occurred. Please try again.' },
+    { status: 500 }
+  )
+}
+```
+
+#### Verification Steps
+- [ ] No passwords, tokens, or secrets in logs
+- [ ] Error messages generic for users
+- [ ] Detailed errors only in server logs
+- [ ] No stack traces exposed to users
+
+### 9. Blockchain Security (Solana)
+
+#### Wallet Verification
+```typescript
+import { verify } from '@solana/web3.js'
+
+async function verifyWalletOwnership(
+  publicKey: string,
+  signature: string,
+  message: string
+) {
+  try {
+    const isValid = verify(
+      Buffer.from(message),
+      Buffer.from(signature, 'base64'),
+      Buffer.from(publicKey, 'base64')
+    )
+    return isValid
+  } catch (error) {
+    return false
+  }
+}
+```
+
+#### Transaction Verification
+```typescript
+async function verifyTransaction(transaction: Transaction) {
+  // Verify recipient
+  if (transaction.to !== expectedRecipient) {
+    throw new Error('Invalid recipient')
+  }
+
+  // Verify amount
+  if (transaction.amount > maxAmount) {
+    throw new Error('Amount exceeds limit')
+  }
+
+  // Verify user has sufficient balance
+  const balance = await getBalance(transaction.from)
+  if (balance < transaction.amount) {
+    throw new Error('Insufficient balance')
+  }
+
+  return true
+}
+```
+
+#### Verification Steps
+- [ ] Wallet signatures verified
+- [ ] Transaction details validated
+- [ ] Balance checks before transactions
+- [ ] No blind transaction signing
+
+### 10. Dependency Security
+
+#### Regular Updates
+```bash
+# Check for vulnerabilities
+npm audit
+
+# Fix automatically fixable issues
+npm audit fix
+
+# Update dependencies
+npm update
+
+# Check for outdated packages
+npm outdated
+```
+
+#### Lock Files
+```bash
+# ALWAYS commit lock files
+git add package-lock.json
+
+# Use in CI/CD for reproducible builds
+npm ci  # Instead of npm install
+```
+
+#### Verification Steps
+- [ ] Dependencies up to date
+- [ ] No known vulnerabilities (npm audit clean)
+- [ ] Lock files committed
+- [ ] Dependabot enabled on GitHub
+- [ ] Regular security updates
+
+## Security Testing
+
+### Automated Security Tests
+```typescript
+// Test authentication
+test('requires authentication', async () => {
+  const response = await fetch('/api/protected')
+  expect(response.status).toBe(401)
+})
+
+// Test authorization
+test('requires admin role', async () => {
+  const response = await fetch('/api/admin', {
+    headers: { Authorization: `Bearer ${userToken}` }
+  })
+  expect(response.status).toBe(403)
+})
+
+// Test input validation
+test('rejects invalid input', async () => {
+  const response = await fetch('/api/users', {
+    method: 'POST',
+    body: JSON.stringify({ email: 'not-an-email' })
+  })
+  expect(response.status).toBe(400)
+})
+
+// Test rate limiting
+test('enforces rate limits', async () => {
+  const requests = Array(101).fill(null).map(() =>
+    fetch('/api/endpoint')
+  )
+
+  const responses = await Promise.all(requests)
+  const tooManyRequests = responses.filter(r => r.status === 429)
+
+  expect(tooManyRequests.length).toBeGreaterThan(0)
+})
+```
+
+## Pre-Deployment Security Checklist
+
+Before ANY production deployment:
+
+- [ ] **Secrets**: No hardcoded secrets, all in env vars
+- [ ] **Input Validation**: All user inputs validated
+- [ ] **SQL Injection**: All queries parameterized
+- [ ] **XSS**: User content sanitized
+- [ ] **CSRF**: Protection enabled
+- [ ] **Authentication**: Proper token handling
+- [ ] **Authorization**: Role checks in place
+- [ ] **Rate Limiting**: Enabled on all endpoints
+- [ ] **HTTPS**: Enforced in production
+- [ ] **Security Headers**: CSP, X-Frame-Options configured
+- [ ] **Error Handling**: No sensitive data in errors
+- [ ] **Logging**: No sensitive data logged
+- [ ] **Dependencies**: Up to date, no vulnerabilities
+- [ ] **Row Level Security**: Enabled in Supabase
+- [ ] **CORS**: Properly configured
+- [ ] **File Uploads**: Validated (size, type)
+- [ ] **Wallet Signatures**: Verified (if blockchain)
+
+## Resources
+
+- [OWASP Top 10](https://owasp.org/www-project-top-ten/)
+- [Next.js Security](https://nextjs.org/docs/security)
+- [Supabase Security](https://supabase.com/docs/guides/auth)
+- [Web Security Academy](https://portswigger.net/web-security)
+
+---
+
+**Remember**: Security is not optional. One vulnerability can compromise the entire platform. When in doubt, err on the side of caution.

--- a/.claude/skills/security-review/cloud-infrastructure-security.md
+++ b/.claude/skills/security-review/cloud-infrastructure-security.md
@@ -1,0 +1,361 @@
+| name | description |
+|------|-------------|
+| cloud-infrastructure-security | Use this skill when deploying to cloud platforms, configuring infrastructure, managing IAM policies, setting up logging/monitoring, or implementing CI/CD pipelines. Provides cloud security checklist aligned with best practices. |
+
+# Cloud & Infrastructure Security Skill
+
+This skill ensures cloud infrastructure, CI/CD pipelines, and deployment configurations follow security best practices and comply with industry standards.
+
+## When to Activate
+
+- Deploying applications to cloud platforms (AWS, Vercel, Railway, Cloudflare)
+- Configuring IAM roles and permissions
+- Setting up CI/CD pipelines
+- Implementing infrastructure as code (Terraform, CloudFormation)
+- Configuring logging and monitoring
+- Managing secrets in cloud environments
+- Setting up CDN and edge security
+- Implementing disaster recovery and backup strategies
+
+## Cloud Security Checklist
+
+### 1. IAM & Access Control
+
+#### Principle of Least Privilege
+
+```yaml
+# PASS: CORRECT: Minimal permissions
+iam_role:
+  permissions:
+    - s3:GetObject  # Only read access
+    - s3:ListBucket
+  resources:
+    - arn:aws:s3:::my-bucket/*  # Specific bucket only
+
+# FAIL: WRONG: Overly broad permissions
+iam_role:
+  permissions:
+    - s3:*  # All S3 actions
+  resources:
+    - "*"  # All resources
+```
+
+#### Multi-Factor Authentication (MFA)
+
+```bash
+# ALWAYS enable MFA for root/admin accounts
+aws iam enable-mfa-device \
+  --user-name admin \
+  --serial-number arn:aws:iam::123456789:mfa/admin \
+  --authentication-code1 123456 \
+  --authentication-code2 789012
+```
+
+#### Verification Steps
+
+- [ ] No root account usage in production
+- [ ] MFA enabled for all privileged accounts
+- [ ] Service accounts use roles, not long-lived credentials
+- [ ] IAM policies follow least privilege
+- [ ] Regular access reviews conducted
+- [ ] Unused credentials rotated or removed
+
+### 2. Secrets Management
+
+#### Cloud Secrets Managers
+
+```typescript
+// PASS: CORRECT: Use cloud secrets manager
+import { SecretsManager } from '@aws-sdk/client-secrets-manager';
+
+const client = new SecretsManager({ region: 'us-east-1' });
+const secret = await client.getSecretValue({ SecretId: 'prod/api-key' });
+const apiKey = JSON.parse(secret.SecretString).key;
+
+// FAIL: WRONG: Hardcoded or in environment variables only
+const apiKey = process.env.API_KEY; // Not rotated, not audited
+```
+
+#### Secrets Rotation
+
+```bash
+# Set up automatic rotation for database credentials
+aws secretsmanager rotate-secret \
+  --secret-id prod/db-password \
+  --rotation-lambda-arn arn:aws:lambda:region:account:function:rotate \
+  --rotation-rules AutomaticallyAfterDays=30
+```
+
+#### Verification Steps
+
+- [ ] All secrets stored in cloud secrets manager (AWS Secrets Manager, Vercel Secrets)
+- [ ] Automatic rotation enabled for database credentials
+- [ ] API keys rotated at least quarterly
+- [ ] No secrets in code, logs, or error messages
+- [ ] Audit logging enabled for secret access
+
+### 3. Network Security
+
+#### VPC and Firewall Configuration
+
+```terraform
+# PASS: CORRECT: Restricted security group
+resource "aws_security_group" "app" {
+  name = "app-sg"
+
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["10.0.0.0/16"]  # Internal VPC only
+  }
+
+  egress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]  # Only HTTPS outbound
+  }
+}
+
+# FAIL: WRONG: Open to the internet
+resource "aws_security_group" "bad" {
+  ingress {
+    from_port   = 0
+    to_port     = 65535
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]  # All ports, all IPs!
+  }
+}
+```
+
+#### Verification Steps
+
+- [ ] Database not publicly accessible
+- [ ] SSH/RDP ports restricted to VPN/bastion only
+- [ ] Security groups follow least privilege
+- [ ] Network ACLs configured
+- [ ] VPC flow logs enabled
+
+### 4. Logging & Monitoring
+
+#### CloudWatch/Logging Configuration
+
+```typescript
+// PASS: CORRECT: Comprehensive logging
+import { CloudWatchLogsClient, CreateLogStreamCommand } from '@aws-sdk/client-cloudwatch-logs';
+
+const logSecurityEvent = async (event: SecurityEvent) => {
+  await cloudwatch.putLogEvents({
+    logGroupName: '/aws/security/events',
+    logStreamName: 'authentication',
+    logEvents: [{
+      timestamp: Date.now(),
+      message: JSON.stringify({
+        type: event.type,
+        userId: event.userId,
+        ip: event.ip,
+        result: event.result,
+        // Never log sensitive data
+      })
+    }]
+  });
+};
+```
+
+#### Verification Steps
+
+- [ ] CloudWatch/logging enabled for all services
+- [ ] Failed authentication attempts logged
+- [ ] Admin actions audited
+- [ ] Log retention configured (90+ days for compliance)
+- [ ] Alerts configured for suspicious activity
+- [ ] Logs centralized and tamper-proof
+
+### 5. CI/CD Pipeline Security
+
+#### Secure Pipeline Configuration
+
+```yaml
+# PASS: CORRECT: Secure GitHub Actions workflow
+name: Deploy
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read  # Minimal permissions
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # Scan for secrets
+      - name: Secret scanning
+        uses: trufflesecurity/trufflehog@main
+
+      # Dependency audit
+      - name: Audit dependencies
+        run: npm audit --audit-level=high
+
+      # Use OIDC, not long-lived tokens
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::123456789:role/GitHubActionsRole
+          aws-region: us-east-1
+```
+
+#### Supply Chain Security
+
+```json
+// package.json - Use lock files and integrity checks
+{
+  "scripts": {
+    "install": "npm ci",  // Use ci for reproducible builds
+    "audit": "npm audit --audit-level=moderate",
+    "check": "npm outdated"
+  }
+}
+```
+
+#### Verification Steps
+
+- [ ] OIDC used instead of long-lived credentials
+- [ ] Secrets scanning in pipeline
+- [ ] Dependency vulnerability scanning
+- [ ] Container image scanning (if applicable)
+- [ ] Branch protection rules enforced
+- [ ] Code review required before merge
+- [ ] Signed commits enforced
+
+### 6. Cloudflare & CDN Security
+
+#### Cloudflare Security Configuration
+
+```typescript
+// PASS: CORRECT: Cloudflare Workers with security headers
+export default {
+  async fetch(request: Request): Promise<Response> {
+    const response = await fetch(request);
+
+    // Add security headers
+    const headers = new Headers(response.headers);
+    headers.set('X-Frame-Options', 'DENY');
+    headers.set('X-Content-Type-Options', 'nosniff');
+    headers.set('Referrer-Policy', 'strict-origin-when-cross-origin');
+    headers.set('Permissions-Policy', 'geolocation=(), microphone=()');
+
+    return new Response(response.body, {
+      status: response.status,
+      headers
+    });
+  }
+};
+```
+
+#### WAF Rules
+
+```bash
+# Enable Cloudflare WAF managed rules
+# - OWASP Core Ruleset
+# - Cloudflare Managed Ruleset
+# - Rate limiting rules
+# - Bot protection
+```
+
+#### Verification Steps
+
+- [ ] WAF enabled with OWASP rules
+- [ ] Rate limiting configured
+- [ ] Bot protection active
+- [ ] DDoS protection enabled
+- [ ] Security headers configured
+- [ ] SSL/TLS strict mode enabled
+
+### 7. Backup & Disaster Recovery
+
+#### Automated Backups
+
+```terraform
+# PASS: CORRECT: Automated RDS backups
+resource "aws_db_instance" "main" {
+  allocated_storage     = 20
+  engine               = "postgres"
+
+  backup_retention_period = 30  # 30 days retention
+  backup_window          = "03:00-04:00"
+  maintenance_window     = "mon:04:00-mon:05:00"
+
+  enabled_cloudwatch_logs_exports = ["postgresql"]
+
+  deletion_protection = true  # Prevent accidental deletion
+}
+```
+
+#### Verification Steps
+
+- [ ] Automated daily backups configured
+- [ ] Backup retention meets compliance requirements
+- [ ] Point-in-time recovery enabled
+- [ ] Backup testing performed quarterly
+- [ ] Disaster recovery plan documented
+- [ ] RPO and RTO defined and tested
+
+## Pre-Deployment Cloud Security Checklist
+
+Before ANY production cloud deployment:
+
+- [ ] **IAM**: Root account not used, MFA enabled, least privilege policies
+- [ ] **Secrets**: All secrets in cloud secrets manager with rotation
+- [ ] **Network**: Security groups restricted, no public databases
+- [ ] **Logging**: CloudWatch/logging enabled with retention
+- [ ] **Monitoring**: Alerts configured for anomalies
+- [ ] **CI/CD**: OIDC auth, secrets scanning, dependency audits
+- [ ] **CDN/WAF**: Cloudflare WAF enabled with OWASP rules
+- [ ] **Encryption**: Data encrypted at rest and in transit
+- [ ] **Backups**: Automated backups with tested recovery
+- [ ] **Compliance**: GDPR/HIPAA requirements met (if applicable)
+- [ ] **Documentation**: Infrastructure documented, runbooks created
+- [ ] **Incident Response**: Security incident plan in place
+
+## Common Cloud Security Misconfigurations
+
+### S3 Bucket Exposure
+
+```bash
+# FAIL: WRONG: Public bucket
+aws s3api put-bucket-acl --bucket my-bucket --acl public-read
+
+# PASS: CORRECT: Private bucket with specific access
+aws s3api put-bucket-acl --bucket my-bucket --acl private
+aws s3api put-bucket-policy --bucket my-bucket --policy file://policy.json
+```
+
+### RDS Public Access
+
+```terraform
+# FAIL: WRONG
+resource "aws_db_instance" "bad" {
+  publicly_accessible = true  # NEVER do this!
+}
+
+# PASS: CORRECT
+resource "aws_db_instance" "good" {
+  publicly_accessible = false
+  vpc_security_group_ids = [aws_security_group.db.id]
+}
+```
+
+## Resources
+
+- [AWS Security Best Practices](https://aws.amazon.com/security/best-practices/)
+- [CIS AWS Foundations Benchmark](https://www.cisecurity.org/benchmark/amazon_web_services)
+- [Cloudflare Security Documentation](https://developers.cloudflare.com/security/)
+- [OWASP Cloud Security](https://owasp.org/www-project-cloud-security/)
+- [Terraform Security Best Practices](https://www.terraform.io/docs/cloud/guides/recommended-practices/)
+
+**Remember**: Cloud misconfigurations are the leading cause of data breaches. A single exposed S3 bucket or overly permissive IAM policy can compromise your entire infrastructure. Always follow the principle of least privilege and defense in depth.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -245,8 +245,15 @@ From spec section 8 — confirm before implementing smart algorithms:
 | `integration-architect` | New endpoint, API contract change, new cross-module dependency (`deps.go`) |
 | `deploy` | User says "deploy", "docker", "CI/CD", "go live", "staging", "production", "health check" |
 | `rbac-hardener` | User says "phân quyền", "rbac", "role guard", "access control", "security audit", or before go-live |
+| `golang-patterns` | Inside `senior-workflow` Phase 4 — idiomatic Go (zero-value, error wrapping, context) |
+| `golang-testing` | Inside `senior-workflow` Phase 4-5 — table-driven tests, race detector, mock patterns |
+| `database-migrations` | Adding/modifying `migrations/` files; goose Up/Down discipline |
+| `security-review` | OWASP scan, secret leakage check, before merging changes that touch auth/RBAC/PII |
+| `code-tour` | Onboarding a reviewer to a multi-file PR; walking through unfamiliar module |
+| `parallel-execution-optimizer` | Multiple independent issues queued — split into worktrees / parallel agents |
+| `recursive-decision-ledger` | Repeated decisions across PRs (filter pattern, hook wiring) — capture into `INSTINCTS.md` |
 
-> **Rule**: `business-auditor` and `integration-architect` run *inside* `senior-workflow` — they do not replace it. `senior-workflow` is always the outer shell. `rbac-hardener` should run at least once before first production deploy.
+> **Rule**: `business-auditor` and `integration-architect` run *inside* `senior-workflow` — they do not replace it. `senior-workflow` is always the outer shell. `rbac-hardener` should run at least once before first production deploy. `golang-patterns` / `golang-testing` are reference skills consulted from inside Phase 4 implementation, not separate phases.
 
 ---
 


### PR DESCRIPTION
## Summary
Adds 7 ECC v2.0.0-rc.1 skills tuned for Go backend work and a node-based PreToolUse hook blocking \`git --no-verify\` / \`-c core.hooksPath=\` bypasses.

### Skills
- \`golang-patterns\`, \`golang-testing\` — idiomatic Go + race-tested table tests
- \`database-migrations\` — goose Up/Down discipline
- \`security-review\` (+ \`cloud-infrastructure-security\`) — OWASP / secret-scan checklist
- \`code-tour\` — multi-file PR walkthroughs
- \`parallel-execution-optimizer\` — worktree fanout for parallel issues
- \`recursive-decision-ledger\` — formalize the \`INSTINCTS.md\` pattern

### Hook
- \`block-no-verify.js\` — wired second in \`PreToolUse[Bash]\` so the existing \`check-commit-message.sh\` still fires first
- Smoke-tested: blocks \`git commit --no-verify\` with exit 2, allows \`git status\`

### CLAUDE.md
- Skills table extended with the 7 new entries plus their auto-activation triggers

## Business rule
- No BR-* touched. Tooling-only change.

## Test plan
- [x] \`node .claude/hooks/block-no-verify.js\` rejects \`git commit --no-verify\` (exit 2)
- [x] \`node .claude/hooks/block-no-verify.js\` allows \`git status\` (exit 0)
- [x] \`python3 -m json.tool\` validates \`.claude/settings.json\`
- [ ] Subsequent commits in this repo still trigger \`check-commit-message.sh\` ASCII/length guard

## Source
https://github.com/affaan-m/ECC/releases/tag/v2.0.0-rc.1