### PR TITLE
ci: switch staging deploy to SSH deploy-stack helper

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,13 +5,13 @@ on:
     branches: [dev]
   workflow_dispatch:
 
-# Serialize per branch: 2 push liên tiếp → cái sau đợi cái trước xong, không cancel
 concurrency:
   group: deploy-${{ github.ref }}
   cancel-in-progress: false
 
 env:
-  IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/vmarble-warehouse-management-service
+  IMAGE_NAME: ghcr.io/giangdq202/vmarble-warehouse-management-service
+  STACK: vwms-be
 
 jobs:
   deploy:
@@ -26,20 +26,17 @@ jobs:
         id: meta
         run: |
           SHORT=$(echo "${{ github.sha }}" | cut -c1-7)
-          IMAGE_LC=$(echo "$IMAGE_NAME" | tr '[:upper:]' '[:lower:]')
-          echo "image=${IMAGE_LC}:sha-${SHORT}" >> "$GITHUB_OUTPUT"
+          echo "image=${IMAGE_NAME}:sha-${SHORT}" >> "$GITHUB_OUTPUT"
 
       - uses: docker/setup-buildx-action@v3
 
-      - name: Login GHCR
-        uses: docker/login-action@v3
+      - uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build & push
-        uses: docker/build-push-action@v5
+      - uses: docker/build-push-action@v5
         with:
           context: .
           push: true
@@ -47,26 +44,16 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Deploy to Portainer
+      - name: Deploy via SSH
         env:
-          PORTAINER_URL: https://deploy.529studio.site
-          PORTAINER_TOKEN: ${{ secrets.PORTAINER_TOKEN }}
-          STACK_ID: ${{ secrets.PORTAINER_STACK_ID }}
-          NEW_IMAGE: ${{ steps.meta.outputs.image }}
+          SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+          SSH_HOST: 163.61.182.158
+          SSH_PORT: 2288
         run: |
-          set -euo pipefail
-          STACK=$(curl -fsS -H "X-API-Key: $PORTAINER_TOKEN" \
-            "$PORTAINER_URL/api/stacks/$STACK_ID")
-          ENDPOINT_ID=$(echo "$STACK" | jq -r '.EndpointId')
-          NEW_ENV=$(echo "$STACK" | jq --arg img "$NEW_IMAGE" \
-            '.Env | map(if .name=="APP_IMAGE" then .value=$img else . end)')
-          FILE=$(curl -fsS -H "X-API-Key: $PORTAINER_TOKEN" \
-            "$PORTAINER_URL/api/stacks/$STACK_ID/file" | jq -r '.StackFileContent')
-          PAYLOAD=$(jq -n --arg c "$FILE" --argjson e "$NEW_ENV" \
-            '{stackFileContent:$c, env:$e, prune:false, pullImage:true}')
-          curl -fsS -X PUT \
-            "$PORTAINER_URL/api/stacks/$STACK_ID?endpointId=$ENDPOINT_ID" \
-            -H "X-API-Key: $PORTAINER_TOKEN" \
-            -H 'Content-Type: application/json' \
-            -d "$PAYLOAD" | jq '{Id, Name, Status}'
-          echo "✓ Deployed $NEW_IMAGE"
+          mkdir -p ~/.ssh
+          echo "$SSH_KEY" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan -p $SSH_PORT $SSH_HOST >> ~/.ssh/known_hosts 2>/dev/null
+          ssh -i ~/.ssh/id_ed25519 -p $SSH_PORT \
+            deploy@$SSH_HOST \
+            "$STACK ${{ steps.meta.outputs.image }}"


### PR DESCRIPTION
## Summary
- Replace Portainer API deploy with SSH call to the restricted `deploy-stack` helper on the staging host (`163.61.182.158:2288`).
- Server-side helper enforces service+image allowlist and per-stack flock; runner only ships stack name + image tag.
- Image is built and pushed to GHCR with immutable `sha-<short>` tag.

## Required secrets (add before merging)
- `DEPLOY_SSH_KEY` — ed25519 private key authorized for `deploy@163.61.182.158`

## Secrets to remove (no longer used)
- `PORTAINER_TOKEN`
- `PORTAINER_STACK_ID`

## Notes / deviations from template
- Branch trigger is `dev` (this repo's staging branch), not `main`/`staging`.
- `STACK: vwms-be` and `IMAGE_NAME: ghcr.io/giangdq202/vmarble-warehouse-management-service` per the BE repo.

## Test plan
- [ ] Add `DEPLOY_SSH_KEY` secret.
- [ ] Merge → push to `dev` triggers `Build & Deploy`.
- [ ] Confirm GHCR has new `sha-<short>` tag.
- [ ] Confirm SSH step exits 0 and host pulls + restarts the `vwms-be` stack.
- [ ] `docker ps --filter name=vwms-be` on staging shows new image digest.
- [ ] App `/healthz` (or equivalent) responds after restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)